### PR TITLE
keyboard: use correct shell integration for maliit-keyboard

### DIFF
--- a/src/keyboard/keyboard.cpp
+++ b/src/keyboard/keyboard.cpp
@@ -30,6 +30,7 @@
 
 int main(int argc, char **argv) {
     setenv("QT_IM_MODULE", "none", true);
+    setenv("QT_WAYLAND_SHELL_INTEGRATION", "inputpanel-shell", true);
 
     QGuiApplication app(argc, argv);
 


### PR DESCRIPTION
Otherwise it would end up using the xdg-shell or whatever default is
from compositor and that may end up with wrongly positioned and treated
by compositor.

Other compositors using the maliit I know uses maliit-server instead so
this does not affect them as far as I understand.