### PR TITLE
Wayland fixes

### DIFF
--- a/src/plugin/inputmethod.cpp
+++ b/src/plugin/inputmethod.cpp
@@ -654,7 +654,8 @@ void InputMethod::onVisibleRectChanged()
 
     QRect visibleRect = d->m_geometry->visibleRect().toRect();
 
-    if (d->m_settings.disableHeight() && QGuiApplication::platformName() == QLatin1String("ubuntumirclient")) {
+    if (d->m_settings.disableHeight() &&
+        (QGuiApplication::platformName() == "ubuntumirclient" || QGuiApplication::platformName() == "wayland")) {
         visibleRect.setHeight(0);
     }
 

--- a/src/plugin/inputmethod_p.h
+++ b/src/plugin/inputmethod_p.h
@@ -185,12 +185,12 @@ public:
 
         if (QGuiApplication::platformName() == QLatin1String("ubuntumirclient")) {
             view->setFlags(InputMethodWindowType); /* Mir-only OSK window type */
-
-            // When keyboard geometry changes, update the window's input mask
-            QObject::connect(m_geometry, &KeyboardGeometry::visibleRectChanged, view, [this]() {
-                view->setMask(m_geometry->visibleRect().toRect());
-            });
         }
+
+        // When keyboard geometry changes, update the window's input mask
+        QObject::connect(m_geometry, &KeyboardGeometry::visibleRectChanged, view, [this]() {
+            view->setMask(m_geometry->visibleRect().toRect());
+        });
     }
 
     void setLayoutOrientation(Qt::ScreenOrientation screenOrientation)


### PR DESCRIPTION
This includes 2 commits:
- Set mask regardless of qt platform, we should always set this regardless of what platform we are on
- Set disabled height on wayland if settings is set, this allows height to be set to 0 if the settings for disabled height is set on wayland also