### PR TITLE
if the screen resolution changes, resize keyboard window

### DIFF
--- a/src/plugin/inputmethod.cpp
+++ b/src/plugin/inputmethod.cpp
@@ -139,6 +139,10 @@ InputMethod::InputMethod(MAbstractInputMethodHost *host)
         d->view->setSource(QUrl::fromLocalFile(g_maliit_keyboard_qml));
     }
     d->view->setGeometry(qGuiApp->primaryScreen()->geometry());
+    connect(qGuiApp->primaryScreen(), &QScreen::geometryChanged,
+            this, [this, d](const QRect &geometry) {
+        d->view->setGeometry(geometry);
+    });
 }
 
 InputMethod::~InputMethod() = default;


### PR DESCRIPTION
Don't break when the screen resolution changes.
this makes it work on compositors that support on the fly
screen resize, or that swap screen width and height on screen rotation