### PR TITLE
Bring back LanguagePluginInterface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,10 +48,12 @@ set(MALIIT_KEYBOARD_LIB_SOURCES
         src/lib/logic/abstractwordengine.h
         src/lib/logic/eventhandler.cpp
         src/lib/logic/eventhandler.h
+        src/lib/logic/languageplugininterface.h
         src/lib/logic/style.cpp
         src/lib/logic/style.h
         src/lib/logic/wordengine.cpp
         src/lib/logic/wordengine.h
+
         src/lib/models/area.cpp
         src/lib/models/area.h
         src/lib/models/key.cpp
@@ -70,6 +72,7 @@ set(MALIIT_KEYBOARD_LIB_SOURCES
         src/lib/models/wordcandidate.h
         src/lib/models/wordribbon.cpp
         src/lib/models/wordribbon.h
+
         src/lib/coreutils.cpp
         src/lib/coreutils.h)
 
@@ -86,7 +89,7 @@ set(WESTERNSUPPORT_SOURCES
         src/lib/logic/abstractlanguageplugin.cpp
         src/lib/logic/abstractlanguageplugin.h)
 
-# TODO install logic/abstractplugininterface.h as HEADERS
+# TODO install logic/languageplugininterface.h and logic/abstractplugininterface.h as HEADERS
 
 set(maliit-keyboard-libraries Qt5::Core)
 set(maliit-keyboard-definitions HUNSPELL_DICT_PATH="${HUNSPELL_DICT_PATH}"

--- a/plugins/ar/src/arabicplugin.h
+++ b/plugins/ar/src/arabicplugin.h
@@ -2,13 +2,14 @@
 #define ARABICPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class ArabicPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "arabicplugin.json")
-
+    Q_INTERFACES(LanguagePluginInterface)
 public:
     explicit ArabicPlugin(QObject* parent = nullptr)
         : WesternLanguagesPlugin(parent)

--- a/plugins/az/src/azerbaijaniplugin.h
+++ b/plugins/az/src/azerbaijaniplugin.h
@@ -2,6 +2,7 @@
 #define AZERBAIJANIPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 //#include <presage.h>
@@ -10,6 +11,7 @@ class AzerbaijaniPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "azerbaijaniplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit AzerbaijaniPlugin(QObject* parent = nullptr)

--- a/plugins/bs/src/bosnianplugin.h
+++ b/plugins/bs/src/bosnianplugin.h
@@ -2,12 +2,14 @@
 #define BOSNIANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class BosnianPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "bosnianplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit BosnianPlugin(QObject* parent = nullptr)

--- a/plugins/ca/src/catalanplugin.h
+++ b/plugins/ca/src/catalanplugin.h
@@ -2,12 +2,14 @@
 #define CATALANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class CatalanPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "catalanplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit CatalanPlugin(QObject* parent = nullptr)

--- a/plugins/chewing/src/chewingplugin.h
+++ b/plugins/chewing/src/chewingplugin.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QStringList>
 #include <QThread>
+#include "languageplugininterface.h"
 #include "abstractlanguageplugin.h"
 
 #include "chewingadapter.h"
@@ -15,6 +16,7 @@ class ChewingPlugin : public AbstractLanguagePlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "chewingplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit ChewingPlugin(QObject *parent = nullptr);

--- a/plugins/cs/src/czechplugin.h
+++ b/plugins/cs/src/czechplugin.h
@@ -2,12 +2,14 @@
 #define CZECHPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class CzechPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "czechplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit CzechPlugin(QObject* parent = nullptr)

--- a/plugins/da/src/danishplugin.h
+++ b/plugins/da/src/danishplugin.h
@@ -2,12 +2,14 @@
 #define DANISHPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class DanishPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "danishplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit DanishPlugin(QObject* parent = nullptr)

--- a/plugins/de/src/germanplugin.h
+++ b/plugins/de/src/germanplugin.h
@@ -2,12 +2,14 @@
 #define GERMANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class GermanPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "germanplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit GermanPlugin(QObject* parent = nullptr)

--- a/plugins/el/src/greekplugin.h
+++ b/plugins/el/src/greekplugin.h
@@ -2,12 +2,14 @@
 #define GREEKPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class GreekPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "greekplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit GreekPlugin(QObject* parent = nullptr)

--- a/plugins/emoji/src/emojiplugin.h
+++ b/plugins/emoji/src/emojiplugin.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QStringList>
+#include "languageplugininterface.h"
 #include "abstractlanguageplugin.h"
 
 #include <iostream>
@@ -13,6 +14,7 @@ class EmojiPlugin : public AbstractLanguagePlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "emojiplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit EmojiPlugin(QObject *parent = nullptr);

--- a/plugins/en/src/englishplugin.h
+++ b/plugins/en/src/englishplugin.h
@@ -2,6 +2,7 @@
 #define ENGLISHPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 //#include <presage.h>
@@ -10,6 +11,7 @@ class EnglishPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "englishplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit EnglishPlugin(QObject* parent = nullptr)

--- a/plugins/eo/src/esperantoplugin.h
+++ b/plugins/eo/src/esperantoplugin.h
@@ -2,12 +2,14 @@
 #define ESPERANTOPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class EsperantoPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "esperantoplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit EsperantoPlugin(QObject* parent = nullptr)

--- a/plugins/es/src/spanishplugin.h
+++ b/plugins/es/src/spanishplugin.h
@@ -2,12 +2,14 @@
 #define SPANISHPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class SpanishPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "spanishplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit SpanishPlugin(QObject* parent = nullptr)

--- a/plugins/fa/src/persianplugin.h
+++ b/plugins/fa/src/persianplugin.h
@@ -2,12 +2,14 @@
 #define PERSIANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class PersianPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "persianplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit PersianPlugin(QObject* parent = nullptr)

--- a/plugins/fi/src/finnishplugin.h
+++ b/plugins/fi/src/finnishplugin.h
@@ -2,12 +2,14 @@
 #define FINNISHPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class FinnishPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "finnishplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit FinnishPlugin(QObject* parent = nullptr)

--- a/plugins/fr/src/frenchplugin.h
+++ b/plugins/fr/src/frenchplugin.h
@@ -2,6 +2,7 @@
 #define FRENCHPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 //#include <presage.h>
@@ -10,6 +11,7 @@ class FrenchPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "frenchplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit FrenchPlugin(QObject* parent = nullptr)

--- a/plugins/gd/src/gaelicplugin.h
+++ b/plugins/gd/src/gaelicplugin.h
@@ -2,6 +2,7 @@
 #define GAELICPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 //#include <presage.h>
@@ -10,6 +11,7 @@ class GaelicPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "gaelicplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit GaelicPlugin(QObject* parent = nullptr)

--- a/plugins/he/src/hebrewplugin.h
+++ b/plugins/he/src/hebrewplugin.h
@@ -2,12 +2,14 @@
 #define HEBREWPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class HebrewPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "hebrewplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit HebrewPlugin(QObject* parent = nullptr)

--- a/plugins/hr/src/croatianplugin.h
+++ b/plugins/hr/src/croatianplugin.h
@@ -2,12 +2,14 @@
 #define CROATIANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class CroatianPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "croatianplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit CroatianPlugin(QObject* parent = nullptr)

--- a/plugins/hu/src/hungarianplugin.h
+++ b/plugins/hu/src/hungarianplugin.h
@@ -2,12 +2,14 @@
 #define HUNGARIANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class HungarianPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "hungarianplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit HungarianPlugin(QObject* parent = nullptr)

--- a/plugins/is/src/icelandicplugin.h
+++ b/plugins/is/src/icelandicplugin.h
@@ -2,12 +2,14 @@
 #define ICELANDICPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class IcelandicPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "icelandicplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit IcelandicPlugin(QObject* parent = nullptr)

--- a/plugins/it/src/italianplugin.h
+++ b/plugins/it/src/italianplugin.h
@@ -2,12 +2,14 @@
 #define ITALIANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class ItalianPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "italianplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit ItalianPlugin(QObject* parent = nullptr)

--- a/plugins/ja/src/japaneseplugin.h
+++ b/plugins/ja/src/japaneseplugin.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QThread>
+#include "languageplugininterface.h"
 #include "abstractlanguageplugin.h"
 
 #include "anthyadapter.h"
@@ -13,6 +14,7 @@ class JapanesePlugin : public AbstractLanguagePlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "japaneseplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit JapanesePlugin(QObject* parent = nullptr);

--- a/plugins/ko/src/koreanplugin.h
+++ b/plugins/ko/src/koreanplugin.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QStringList>
+#include "languageplugininterface.h"
 #include "abstractlanguageplugin.h"
 #include "candidatescallback.h"
 #include "spellchecker.h"
@@ -17,6 +18,7 @@ class KoreanPlugin : public AbstractLanguagePlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "koreanplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit KoreanPlugin(QObject *parent = nullptr);

--- a/plugins/lv/src/latvianplugin.h
+++ b/plugins/lv/src/latvianplugin.h
@@ -2,12 +2,14 @@
 #define LATVIANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class LatvianPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "latvianplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit LatvianPlugin(QObject* parent = nullptr)

--- a/plugins/nb/src/norwegianplugin.h
+++ b/plugins/nb/src/norwegianplugin.h
@@ -2,12 +2,14 @@
 #define NORWEGIANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class NorwegianPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "norwegianplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit NorwegianPlugin(QObject* parent = nullptr)

--- a/plugins/nl/src/dutchplugin.h
+++ b/plugins/nl/src/dutchplugin.h
@@ -2,12 +2,14 @@
 #define DUTCHPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class DutchPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "dutchplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit DutchPlugin(QObject* parent = nullptr)

--- a/plugins/pinyin/src/pinyinplugin.h
+++ b/plugins/pinyin/src/pinyinplugin.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QStringList>
 #include <QThread>
+#include "languageplugininterface.h"
 #include "abstractlanguageplugin.h"
 
 #include "pinyinadapter.h"
@@ -15,6 +16,7 @@ class PinyinPlugin : public AbstractLanguagePlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "pinyinplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit PinyinPlugin(QObject *parent = nullptr);

--- a/plugins/pl/src/polishplugin.h
+++ b/plugins/pl/src/polishplugin.h
@@ -2,12 +2,14 @@
 #define POLISHPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class PolishPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "polishplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit PolishPlugin(QObject* parent = nullptr)

--- a/plugins/pt/src/portugueseplugin.h
+++ b/plugins/pt/src/portugueseplugin.h
@@ -2,12 +2,14 @@
 #define PORTUGUESEPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class PortuguesePlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "portugueseplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit PortuguesePlugin(QObject* parent = nullptr)

--- a/plugins/ro/src/romanianplugin.h
+++ b/plugins/ro/src/romanianplugin.h
@@ -2,12 +2,14 @@
 #define ROMANIANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class RomanianPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "romanianplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit RomanianPlugin(QObject* parent = nullptr)
@@ -19,4 +21,3 @@ public:
 };
 
 #endif // ROMANIANPLUGIN_H
-

--- a/plugins/ru/src/russianplugin.h
+++ b/plugins/ru/src/russianplugin.h
@@ -2,12 +2,14 @@
 #define RUSSIANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class RussianPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "russianplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit RussianPlugin(QObject* parent = nullptr)

--- a/plugins/sl/src/slovenianplugin.h
+++ b/plugins/sl/src/slovenianplugin.h
@@ -2,12 +2,14 @@
 #define SLOVENIANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class SlovenianPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "slovenianplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit SlovenianPlugin(QObject* parent = nullptr)

--- a/plugins/sr/src/serbianplugin.h
+++ b/plugins/sr/src/serbianplugin.h
@@ -2,12 +2,14 @@
 #define SERBIANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class SerbianPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "serbianplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit SerbianPlugin(QObject* parent = nullptr)

--- a/plugins/sv/src/swedishplugin.h
+++ b/plugins/sv/src/swedishplugin.h
@@ -2,12 +2,14 @@
 #define SWEDISHPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class SwedishPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "swedishplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit SwedishPlugin(QObject* parent = nullptr)

--- a/plugins/uk/src/ukrainianplugin.h
+++ b/plugins/uk/src/ukrainianplugin.h
@@ -2,12 +2,14 @@
 #define UKRAINIANPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class UkrainianPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "ukrainianplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit UkrainianPlugin(QObject* parent = nullptr)

--- a/plugins/westernsupport/westernlanguagesplugin.h
+++ b/plugins/westernsupport/westernlanguagesplugin.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 
+#include "languageplugininterface.h"
 #include "westernlanguagefeatures.h"
 #include "spellchecker.h"
 #include "abstractlanguageplugin.h"
@@ -18,6 +19,7 @@ class SpellPredictWorker;
 class WesternLanguagesPlugin : public AbstractLanguagePlugin
 {
     Q_OBJECT
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit WesternLanguagesPlugin(QObject *parent = nullptr);

--- a/src/lib/logic/abstractlanguageplugin.h
+++ b/src/lib/logic/abstractlanguageplugin.h
@@ -30,24 +30,25 @@
 
 #include <QObject>
 
-class AbstractLanguageFeatures;
+#include "languageplugininterface.h"
 
-class AbstractLanguagePlugin : public QObject
+class AbstractLanguagePlugin : public QObject, public LanguagePluginInterface
 {
     Q_OBJECT
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     AbstractLanguagePlugin(QObject *parent = nullptr);
     ~AbstractLanguagePlugin() override;
 
-    virtual void predict(const QString& surroundingLeft, const QString& preedit);
-    virtual void wordCandidateSelected(QString word);
-    virtual AbstractLanguageFeatures* languageFeature();
+    void predict(const QString& surroundingLeft, const QString& preedit) override;
+    void wordCandidateSelected(QString word) override;
+    AbstractLanguageFeatures* languageFeature() override;
 
     //! spell checker
-    virtual void spellCheckerSuggest(const QString& word, int limit);
-    virtual void addToSpellCheckerUserWordList(const QString& word);
-    virtual bool setLanguage(const QString& languageId, const QString& pluginPath);
+    void spellCheckerSuggest(const QString& word, int limit) override;
+    void addToSpellCheckerUserWordList(const QString& word) override;
+    bool setLanguage(const QString& languageId, const QString& pluginPath) override;
 
 signals:
     void newSpellingSuggestions(QString word, QStringList suggestions);

--- a/src/lib/logic/languageplugininterface.h
+++ b/src/lib/logic/languageplugininterface.h
@@ -1,0 +1,30 @@
+#ifndef LANGUAGEPLUGININTERFACE_H
+#define LANGUAGEPLUGININTERFACE_H
+
+#include <QString>
+#include <QStringList>
+
+class AbstractLanguageFeatures;
+
+class LanguagePluginInterface
+{
+public:
+    virtual ~LanguagePluginInterface() = default;
+
+    virtual void predict(const QString& surroundingLeft, const QString& preedit) = 0;
+    virtual void wordCandidateSelected(QString word) = 0;
+
+    virtual AbstractLanguageFeatures* languageFeature() = 0;
+
+    //! spell checker
+    virtual void spellCheckerSuggest(const QString& word, int limit) = 0;
+    virtual void addToSpellCheckerUserWordList(const QString& word) = 0;
+    virtual bool setLanguage(const QString& languageId, const QString &pluginPath) = 0;
+};
+
+#define LanguagePluginInterface_iid "com.canonical.UbuntuKeyboard.LanguagePluginInterface"
+
+Q_DECLARE_INTERFACE(LanguagePluginInterface, LanguagePluginInterface_iid)
+
+#endif // LANGUAGEPLUGININTERFACE_H
+

--- a/src/lib/logic/wordengine.cpp
+++ b/src/lib/logic/wordengine.cpp
@@ -60,7 +60,7 @@ public:
 
     bool clear_candidates_on_incoming;
 
-    AbstractLanguagePlugin* languagePlugin;
+    LanguagePluginInterface* languagePlugin;
 
     QPluginLoader pluginLoader;
 
@@ -94,7 +94,7 @@ public:
         QObject *plugin = pluginLoader.instance();
 
         if (plugin) {
-            languagePlugin = qobject_cast<AbstractLanguagePlugin *>(plugin);
+            languagePlugin = qobject_cast<LanguagePluginInterface *>(plugin);
             if (!languagePlugin) {
                 qCritical() << "wordengine.cpp - loading plugin failed: " + pluginPath;
 
@@ -411,9 +411,9 @@ void WordEngine::onLanguageChanged(const QString &pluginPath, const QString &lan
 
     Q_EMIT enabledChanged(isEnabled());
 
-    connect(d->languagePlugin, &AbstractLanguagePlugin::newSpellingSuggestions,
+    connect(static_cast<AbstractLanguagePlugin *>(d->languagePlugin), &AbstractLanguagePlugin::newSpellingSuggestions,
             this, &WordEngine::newSpellingSuggestions);
-    connect(d->languagePlugin, &AbstractLanguagePlugin::newPredictionSuggestions,
+    connect(static_cast<AbstractLanguagePlugin *>(d->languagePlugin), &AbstractLanguagePlugin::newPredictionSuggestions,
             this, &WordEngine::newPredictionSuggestions);
     Q_EMIT pluginChanged();
 }

--- a/src/lib/logic/wordengine.h
+++ b/src/lib/logic/wordengine.h
@@ -35,6 +35,7 @@
 #include "models/text.h"
 #include "logic/abstractwordengine.h"
 #include "logic/abstractlanguagefeatures.h"
+#include "languageplugininterface.h"
 
 #include <QtCore>
 #include <QMutex>

--- a/tests/testlayout/src/testlayoutplugin.h
+++ b/tests/testlayout/src/testlayoutplugin.h
@@ -2,12 +2,14 @@
 #define TESTLAYOUTPLUGIN_H
 
 #include <QObject>
+#include "languageplugininterface.h"
 #include "westernlanguagesplugin.h"
 
 class TestLayoutPlugin : public WesternLanguagesPlugin
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "io.maliit.keyboard.LanguagePlugin.1" FILE "testlayoutplugin.json")
+    Q_INTERFACES(LanguagePluginInterface)
 
 public:
     explicit TestLayoutPlugin(QObject* parent = 0)


### PR DESCRIPTION
Without this maliit-server is unable to cast the language plugin causing
a segfault rendering maliit-server non functional.

This partly reverts commit 1e5aa06d579fcd65fb6640b23b70318386ba3564.