### PR TITLE
Provide a desktop file for maliit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,9 @@ install(FILES qml/images/keyboard_spacebar@27.png
 install(FILES data/schemas/org.maliit.keyboard.maliit.gschema.xml
         DESTINATION share/glib-2.0/schemas/)
 
+install(FILES com.github.maliit.keyboard.desktop
+        DESTINATION share/applications)
+
 # TODO add all tests
 if(enable-tests)
     enable_testing()

--- a/com.github.maliit.keyboard.desktop
+++ b/com.github.maliit.keyboard.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Maliit
+Exec=maliit-keyboard
+Type=Application
+X-KDE-Wayland-VirtualKeyboard=true
+Icon=input-keyboard-virtual
+NoDisplay=true


### PR DESCRIPTION
This way it can be used for easily listing on configuration modules.

Here's some context:
* https://invent.kde.org/frameworks/kservice/-/merge_requests/35
* https://invent.kde.org/plasma/kwin/-/merge_requests/565