### PR TITLE
Set haptic feedback duration to 150ms

### DIFF
--- a/src/plugin/feedback.cpp
+++ b/src/plugin/feedback.cpp
@@ -43,7 +43,7 @@ Feedback::Feedback(const KeyboardSettings *settings)
     m_pressEffect->setAttackIntensity(0.0);
     m_pressEffect->setAttackTime(50);
     m_pressEffect->setIntensity(1.0);
-    m_pressEffect->setDuration(10);
+    m_pressEffect->setDuration(150);
     m_pressEffect->setFadeTime(50);
     m_pressEffect->setFadeIntensity(0.0);
 #endif


### PR DESCRIPTION
10ms is bit too fast to notice.

I tested this on PinePhone device with ffmemless driver, and 10ms barely activates vibrator gpio driver before simply turning it off.