### PR TITLE
themes: add Breeze color schemes

### DIFF
--- a/data/themes/Breeze.json
+++ b/data/themes/Breeze.json
@@ -1,0 +1,16 @@
+{
+    "fontColor": "#686868",
+    "selectionColor": "#3daee9",
+    "backgroundColor": "#ededed",
+    "dividerColor": "#cdcdcd",
+    "annotationFontColor": "#686868",
+    "charKeyColor": "#fcfcfc",
+    "charKeyPressedColor": "#d6d6d6",
+    "actionKeyColor": "#f5f5f5",
+    "actionKeyPressedColor": "#d0d0d0",
+    "toolkitTheme": "Ubuntu.Components.Themes.Ambiance",
+    "popupBorderColor": "#888888",
+    "keyBorderEnabled": false,
+    "charKeyBorderColor": "white",
+    "actionKeyBorderColor": "white"
+}

--- a/data/themes/BreezeDark.json
+++ b/data/themes/BreezeDark.json
@@ -1,0 +1,16 @@
+{
+    "fontColor": "#b4b4b4",
+    "selectionColor": "#3daee9",
+    "backgroundColor": "#333333",
+    "dividerColor": "#cdcdcd",
+    "annotationFontColor": "#b4b4b4",
+    "charKeyColor": "#414141",
+    "charKeyPressedColor": "#373737",
+    "actionKeyColor": "#3b3b3b",
+    "actionKeyPressedColor": "#2f2f2f",
+    "toolkitTheme": "Ubuntu.Components.Themes.Ambiance",
+    "popupBorderColor": "#888888",
+    "keyBorderEnabled": false,
+    "charKeyBorderColor": "white",
+    "actionKeyBorderColor": "white"
+} 


### PR DESCRIPTION
This theme is used in Plasma Mobile currently.

If you prefer to not ship this in maliit repo, let me know and I will ship this in plasma-phone-components or something. That said there already is for example ubuntu specific colorschemes here, so this does not hurt. Thoughts welcome.

Authored-by: Devin Lin