### PR TITLE
Provide sensible default sizing

### DIFF
--- a/data/devices/default.json
+++ b/data/devices/default.json
@@ -33,8 +33,8 @@
   "wordRibbonHeight": 4,
   "wordRibbonFontSize": 14,
 
-  "keyboardHeightPortrait": 0.40,
-  "keyboardHeightLandscape": 0.49,
+  "keyboardHeightPortrait": 0.30,
+  "keyboardHeightLandscape": 0.39,
 
   "flickMargin": 1.5,
   "flickBorderWidth": 0.1


### PR DESCRIPTION
Current sizing is bit too huge, and results in stretched keyboard keys.
which looks bit weird, and also is not usable in vertical form factor at
all.

Before:
![Screenshot_20210304_043657](https://user-images.githubusercontent.com/1061944/109945390-330d1e80-7cfd-11eb-8ee2-080746476070.png)


After:

![Screenshot_20210304_043909](https://user-images.githubusercontent.com/1061944/109945196-035e1680-7cfd-11eb-8ad0-931b40340871.png)
