### PR TITLE
Fix BreezeDark theme divider color

### DIFF
--- a/data/themes/BreezeDark.json
+++ b/data/themes/BreezeDark.json
@@ -2,7 +2,7 @@
     "fontColor": "#b4b4b4",
     "selectionColor": "#3daee9",
     "backgroundColor": "#333333",
-    "dividerColor": "#cdcdcd",
+    "dividerColor": "#3d3d3d",
     "annotationFontColor": "#b4b4b4",
     "charKeyColor": "#414141",
     "charKeyPressedColor": "#373737",


### PR DESCRIPTION
The BreezeDark theme divider color was made to be too light, darken it a bit so it does not stick out.

Before:

![Screenshot_20210305_233209](https://user-images.githubusercontent.com/7444510/110195544-f5e38200-7e0b-11eb-8492-88dd25cc4ba9.png)

After:

![Screenshot_20210305_233810](https://user-images.githubusercontent.com/7444510/110195553-f9770900-7e0b-11eb-9a68-bdbb0763f4c6.png)