### PR TITLE
Fix incorrect key name in tablet.json

### DIFF
--- a/data/devices/tablet.json
+++ b/data/devices/tablet.json
@@ -30,7 +30,7 @@
 
   "emailLayoutUrlKeyPadding": 1.5,
 
-  "wordribbonHeight": 6,
+  "wordRibbonHeight": 6,
   "wordRibbonFontSize": 17,
 
   "keyboardHeightPortrait": 0.31,


### PR DESCRIPTION
The key name should be `wordRibbonHeight`.