### PR TITLE
Optimise keyboard for Simplified Chinese

### DIFF
--- a/plugins/pinyin/qml/Keyboard_zh-hans.qml
+++ b/plugins/pinyin/qml/Keyboard_zh-hans.qml
@@ -37,13 +37,13 @@ KeyPad {
 
             CharKey { label: "q"; shifted: "Q"; extended: ["1"]; extendedShifted: ["1"]; leftSide: true; }
             CharKey { label: "w"; shifted: "W"; extended: ["2"]; extendedShifted: ["2"] }
-            CharKey { label: "e"; shifted: "E"; extended: ["3", "è", "é", "ê", "ë", "€"]; extendedShifted: ["3", "È", "É", "Ê", "Ë", "€"] }
+            CharKey { label: "e"; shifted: "E"; extended: ["3", "ē", "é", "ě", "è"]; extendedShifted: ["3", "Ē", "É", "Ě", "È"] }
             CharKey { label: "r"; shifted: "R"; extended: ["4"]; extendedShifted: ["4"] }
-            CharKey { label: "t"; shifted: "T"; extended: ["5", "þ"]; extendedShifted: ["5", "Þ"] }
-            CharKey { label: "y"; shifted: "Y"; extended: ["6", "ý", "¥"]; extendedShifted: ["6", "Ý", "¥"] }
-            CharKey { label: "u"; shifted: "U"; extended: ["7","û","ù","ú","ü"]; extendedShifted: ["7","Û","Ù","Ú","Ü"] }
-            CharKey { label: "i"; shifted: "I"; extended: ["8", "î","ï","ì","í"]; extendedShifted: ["8","Î","Ï","Ì","Í"] }
-            CharKey { label: "o"; shifted: "O"; extended: ["9", "ö","ô","ò","ó"]; extendedShifted: ["9","Ö","Ô","Ò","Ó"] }
+            CharKey { label: "t"; shifted: "T"; extended: ["5"]; extendedShifted: ["5"] }
+            CharKey { label: "y"; shifted: "Y"; extended: ["6", "¥"]; extendedShifted: ["6", "¥"] }
+            CharKey { label: "u"; shifted: "U"; extended: ["7", "ū", "ú", "ǔ", "ù"]; extendedShifted: ["7", "Ū", "Ú", "Ǔ","Ù"] }
+            CharKey { label: "i"; shifted: "I"; extended: ["8", "ī", "í", "ǐ", "ì"]; extendedShifted: ["8", "Ī", "Í", "Ǐ", "Ì"] }
+            CharKey { label: "o"; shifted: "O"; extended: ["9", "ō", "ó", "ǒ", "ò"]; extendedShifted: ["9", "Ō", "Ó", "Ǒ", "Ò"] }
             CharKey { label: "p"; shifted: "P"; extended: ["0"]; extendedShifted: ["0"]; rightSide: true; }
         }
 
@@ -51,7 +51,7 @@ KeyPad {
             anchors.horizontalCenter: parent.horizontalCenter;
             spacing: 0
 
-            CharKey { label: "a"; shifted: "A"; leftSide: true; }
+            CharKey { label: "a"; shifted: "A"; extended: ["ā", "á", "ǎ", "à"]; extendedShifted: ["Ā", "Á", "Ǎ", "À"]; leftSide: true; }
             CharKey { label: "s"; shifted: "S"; }
             CharKey { label: "d"; shifted: "D"; }
             CharKey { label: "f"; shifted: "F"; }
@@ -70,7 +70,7 @@ KeyPad {
             CharKey { label: "z"; shifted: "Z"; }
             CharKey { label: "x"; shifted: "X"; }
             CharKey { label: "c"; shifted: "C"; }
-            CharKey { label: "v"; shifted: "V"; }
+            CharKey { label: "v"; shifted: "V"; extended: ["ü", "ǖ", "ǘ", "ǚ", "ǜ"]; extendedShifted: ["Ü", "Ǖ", "Ǘ", "Ǚ", "Ǜ"] }
             CharKey { label: "b"; shifted: "B"; }
             CharKey { label: "n"; shifted: "N"; }
             CharKey { label: "m"; shifted: "M"; }

--- a/plugins/pinyin/qml/Keyboard_zh-hans.qml
+++ b/plugins/pinyin/qml/Keyboard_zh-hans.qml
@@ -24,7 +24,7 @@ KeyPad {
     anchors.fill: parent
 
     content: c1
-    symbols: "languages/Keyboard_symbols.qml"
+    symbols: "languages/Keyboard_symbols_zh-hans.qml"
 
     Column {
         id: c1
@@ -85,9 +85,9 @@ KeyPad {
 
             SymbolShiftKey { id: symShiftKey; label: "符号";              anchors.left: parent.left; height: parent.height; }
             LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
-            CharKey        { id: commaKey;    label: ","; shifted: "，";  anchors.left: languageMenuButton.right; height: parent.height; }
+            CharKey        { id: commaKey;    label: "，"; shifted: ",";  anchors.left: languageMenuButton.right; height: parent.height; }
             SpaceKey       { id: spaceKey;                               anchors.left: commaKey.right; anchors.right: dotKey.left; noMagnifier: true; height: parent.height; }
-            CharKey        { id: dotKey;      label: "。"; shifted: "。"; anchors.right: enterKey.left; height: parent.height; }
+            CharKey        { id: dotKey;      label: "。"; shifted: "."; anchors.right: enterKey.left; height: parent.height; }
             ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
         }
     } // column

--- a/qml/languages/Keyboard_symbols_zh-hans.qml
+++ b/qml/languages/Keyboard_symbols_zh-hans.qml
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2013 Canonical Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+
+import MaliitKeyboard 2.0
+
+import "../keys"
+
+KeyPad {
+    anchors.fill: parent
+
+    content: c1
+
+    Column {
+        id: c1
+        anchors.fill: parent
+        anchors.margins: 0;
+
+        spacing: 0
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            anchors.margins: 50;
+            spacing: 0
+
+            CharKey { label: "1"; shifted: "€"; leftSide: true; }
+            CharKey { label: "2"; shifted: "£"; }
+            CharKey { label: "3"; shifted: "$"; }
+            CharKey { label: "4"; shifted: "¥"; }
+            CharKey { label: "5"; shifted: "…"; }
+            CharKey { label: "6"; shifted: "%"; }
+            CharKey { label: "7"; shifted: "<"; }
+            CharKey { label: "8"; shifted: ">"; }
+            CharKey { label: "9"; shifted: "["; extendedShifted: ["【", "〔", "［"] }
+            CharKey { label: "0"; shifted: "]"; extendedShifted: ["】", "〕", "］"]; rightSide: true; }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            anchors.margins: 50;
+            spacing: 0
+
+            CharKey { label: "*"; shifted: "`"; leftSide: true; }
+            CharKey { label: "#"; shifted: "^"; }
+            CharKey { label: "+"; shifted: "|"; }
+            CharKey { label: "-"; shifted: "_"; extended: ["—", "–", "•"]; }
+            CharKey { label: "="; shifted: "§"; }
+            CharKey { label: "（"; shifted: "{"; extended: ["("] }
+            CharKey { label: "）"; shifted: "}"; extended: [")"]}
+            CharKey { label: "！"; shifted: "¡"; extended: ["!"] }
+            CharKey { label: "？"; shifted: "¿"; extended: ["?"]; rightSide: true; }
+        }
+
+        Row {
+            anchors.horizontalCenter: parent.horizontalCenter;
+            anchors.margins: 50;
+            spacing: 0
+
+            OneTwoKey { label: "1/2"; shifted: "2/2"; fontSize: Device.fontSize; }
+            CharKey { label: "@"; shifted: "《"; extendedShifted: ["〈", "«", "‹"]; }
+            CharKey { label: "~"; shifted: "》"; extendedShifted: ["〉", "»", "›"]; }
+            CharKey { label: "/"; shifted: "“"; extendedShifted: ["\"", "‘"]; }
+            CharKey { label: "\\"; shifted: "”"; extendedShifted: ["\"", "’"]; }
+            CharKey { label: "'"; shifted: "「"; extendedShifted: ["『"]; }
+            CharKey { label: "；"; shifted: "」"; extended: [";"]; extendedShifted: ["』"]; }
+            CharKey { label: "："; shifted: "&"; extended: [":"]; }
+            BackspaceKey {}
+        }
+
+        Item {
+            anchors.left: parent.left
+            anchors.right: parent.right
+
+            height: panel.keyHeight + Device.bottom_margin*2;
+
+            SymbolShiftKey { id: symShiftKey; label: "ABC"; shifted: "ABC"; anchors.left: parent.left; height: parent.height; }
+            CharKey        { id: commaKey;    label: "，"; shifted: "/"; extended: [","];    anchors.left: symShiftKey.right; height: parent.height; }
+            SpaceKey       { id: spaceKey;                                  anchors.left: commaKey.right; anchors.right: dotKey.left; noMagnifier: true; height: parent.height }
+            CharKey        { id: dotKey;      label: "。"; shifted: "."; extended: ["."];    anchors.right: enterKey.left; height: parent.height; }
+            ReturnKey      { id: enterKey;                                  anchors.right: parent.right; height: parent.height; }
+        }
+    } // column
+}


### PR DESCRIPTION
In this pull request, we made two changes.
1. Make the extended area of the main keyboard display only valid pinyin symbols.
2. Optimise the symbol area for Simplified Chinese by using full-width punctuations by default, and adding half-width characters to the extended area.

Something to consider before merging: putting `Keyboard_symbols_zh-hans.qml` in the same directory as `Keyboard_symbols.qml` does not look elegant enough, as if one adds more languages like this, `qml/languages` will just contain too many files. I would rather put it under `plugins/pinyin/qml` but what would be the correct way to refer to the symbols file in `Keyboard_zh-hans.qml`?