### PR TITLE
Make sure Settings also work when running on Plasma

### DIFF
--- a/qml/keys/LanguageMenu.qml
+++ b/qml/keys/LanguageMenu.qml
@@ -47,7 +47,7 @@ Menu {
         id: settingsItem
         text: qsTr("Settings") + "…"
         onClicked: {
-            Qt.openUrlExternally("settings:///system/language")
+            Keyboard.showSystemSettings();
             canvas.languageMenu.close();
             maliit_input_method.hide();
         }

--- a/src/plugin/inputmethod.cpp
+++ b/src/plugin/inputmethod.cpp
@@ -755,3 +755,20 @@ void InputMethod::onPluginPathsChanged(const QStringList& pluginPaths) {
 
     d->updateLanguagesPaths();
 }
+
+void InputMethod::showSystemSettings()
+{
+    // Make sure we are not forcing the inputpanel-shell into the processes we issue
+    auto previous = qgetenv("QT_WAYLAND_SHELL_INTEGRATION");
+    qunsetenv("QT_WAYLAND_SHELL_INTEGRATION");
+
+    if (qgetenv("XDG_CURRENT_DESKTOP") == "KDE") {
+        QDesktopServices::openUrl(QUrl("systemsettings://kcm_virtualkeyboard"));
+    } else {
+        QDesktopServices::openUrl(QUrl("settings://system/language"));
+    }
+
+    if (!previous.isEmpty()) {
+        qputenv("QT_WAYLAND_SHELL_INTEGRATION", previous);
+    }
+}

--- a/src/plugin/inputmethod.h
+++ b/src/plugin/inputmethod.h
@@ -145,6 +145,8 @@ public:
 
     Q_SLOT void onPluginPathsChanged(const QStringList& pluginPaths);
 
+    Q_INVOKABLE void showSystemSettings();
+
 Q_SIGNALS:
     void contentTypeChanged(TextContentType contentType);
     void activateAutocaps();


### PR DESCRIPTION
Moves the call into a C++ class.
Checks the system being run using the XDG_CURRENT_DESKTOP.
Prevents us from forwarding the QT_WAYLAND_SHELL_INTEGRATION value to
the child process, since it will not work as expected as we are
enforcing a private one. Made the switch for all desktops as I
understand it's the same problem elsewhere.

Note, this will only work properly as of Plasma 5.23 (October). The current case is already broken so I'd say we can safely get this in and eventually have it all converge.