### PR TITLE
left/right arrow keypress: Don't check for surrounding text

### DIFF
--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -293,6 +293,10 @@ Item {
                 processSwipe(mouseX, mouseY)
             }
 
+            onMouseYChanged: {
+                processSwipe(mouseX, mouseY)
+            }
+
             onPressed: {
                 prevSwipePositionX = mouseX
                 prevSwipePositionY = mouseY
@@ -366,10 +370,10 @@ Item {
     }
 
     function processSwipe(positionX, positionY) {
-        if (positionX < prevSwipePositionX - Device.gu(1) && input_method.surroundingLeft != "") {
+        if (positionX < prevSwipePositionX - Device.gu(1)) {
             sendLeftKey();
             prevSwipePositionX = positionX
-        } else if (positionX > prevSwipePositionX + Device.gu(1) && input_method.surroundingRight != "") {
+        } else if (positionX > prevSwipePositionX + Device.gu(1)) {
             sendRightKey();
             prevSwipePositionX = positionX
         }


### PR DESCRIPTION
## Summary
 * Some apps (like `Konsole`) seem to not correctly report whether there is content after the cursor.
 * This was causing right swipes to not move the cursor to the right.
 * Additionally, `processSwipe` was only called `onMouseXChanged`, while `processSwipe` currently takes action on both horizontal and vertical input.