### PR TITLE
Bring back support for icon themes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,18 +378,6 @@ install(DIRECTORY data/themes
         DESTINATION ${MALIIT_KEYBOARD_DATA_DIR})
 install(DIRECTORY data/devices
         DESTINATION ${MALIIT_KEYBOARD_DATA_DIR})
-install(FILES data/styles/ubuntu/images/icon_backspace@18.png
-        DESTINATION ${MALIIT_KEYBOARD_DATA_DIR}/icons
-        RENAME erase.png)
-install(FILES data/styles/ubuntu/images/icon_enter@18.png
-        DESTINATION ${MALIIT_KEYBOARD_DATA_DIR}/icons
-        RENAME keyboard-enter.png)
-install(FILES data/styles/ubuntu/images/language-icon.png
-        DESTINATION ${MALIIT_KEYBOARD_DATA_DIR}/icons
-        RENAME language-chooser.png)
-install(FILES qml/images/keyboard_spacebar@27.png
-        DESTINATION ${MALIIT_KEYBOARD_DATA_DIR}/icons
-        RENAME keyboard_spacebar.png)
 install(FILES data/schemas/org.maliit.keyboard.maliit.gschema.xml
         DESTINATION share/glib-2.0/schemas/)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,8 @@ set(MALIIT_KEYBOARD_COMMON_SOURCES
         src/plugin/greeterstatus.h
         src/plugin/updatenotifier.cpp
         src/plugin/updatenotifier.h
+        src/plugin/iconprovider.cpp
+        src/plugin/iconprovider.h
         src/plugin/inputmethod.cpp
         src/plugin/inputmethod.h
         src/plugin/inputmethod_p.h

--- a/data/themes/Ambiance.json
+++ b/data/themes/Ambiance.json
@@ -1,4 +1,5 @@
 {
+    "iconTheme": "suru",
     "fontColor": "#333333",
     "selectionColor": "#19B6EE",
     "backgroundColor": "#f7f7f7",

--- a/data/themes/BorderedBlack.json
+++ b/data/themes/BorderedBlack.json
@@ -1,4 +1,5 @@
 {
+    "iconTheme": "suru",
     "fontColor": "white",
     "selectionColor": "#19B6EE",
     "backgroundColor": "#111111",

--- a/data/themes/BorderedGrey.json
+++ b/data/themes/BorderedGrey.json
@@ -1,4 +1,5 @@
 {
+    "iconTheme": "suru",
     "fontColor": "white",
     "selectionColor": "#19B6EE",
     "backgroundColor": "#3B3B3B",

--- a/data/themes/BorderedWhite.json
+++ b/data/themes/BorderedWhite.json
@@ -1,4 +1,5 @@
 {
+    "iconTheme": "suru",
     "fontColor": "#333333",
     "selectionColor": "#19B6EE",
     "backgroundColor": "white",

--- a/data/themes/Breeze.json
+++ b/data/themes/Breeze.json
@@ -1,4 +1,5 @@
 {
+    "iconTheme": "breeze",
     "fontColor": "#686868",
     "selectionColor": "#3daee9",
     "backgroundColor": "#ededed",

--- a/data/themes/BreezeDark.json
+++ b/data/themes/BreezeDark.json
@@ -1,4 +1,5 @@
 {
+    "iconTheme": "breeze",
     "fontColor": "#b4b4b4",
     "selectionColor": "#3daee9",
     "backgroundColor": "#333333",

--- a/data/themes/JustBlack.json
+++ b/data/themes/JustBlack.json
@@ -1,4 +1,5 @@
 {
+    "iconTheme": "suru",
     "fontColor": "white",
     "selectionColor": "#19B6EE",
     "backgroundColor": "#111111",

--- a/data/themes/JustGrey.json
+++ b/data/themes/JustGrey.json
@@ -1,4 +1,5 @@
 {
+    "iconTheme": "suru",
     "fontColor": "white",
     "selectionColor": "#19B6EE",
     "backgroundColor": "#3B3B3B",

--- a/data/themes/JustWhite.json
+++ b/data/themes/JustWhite.json
@@ -1,4 +1,5 @@
 {
+    "iconTheme": "suru",
     "fontColor": "#333333",
     "selectionColor": "#19B6EE",
     "backgroundColor": "white",

--- a/data/themes/SuruBlack.json
+++ b/data/themes/SuruBlack.json
@@ -1,4 +1,5 @@
 {
+    "iconTheme": "suru",
     "fontColor": "#CDCDCD",
     "selectionColor": "#19B6EE",
     "backgroundColor": "#3B3B3B",

--- a/data/themes/SuruDark.json
+++ b/data/themes/SuruDark.json
@@ -1,4 +1,5 @@
 {
+    "iconTheme": "suru",
     "fontColor": "#CDCDCD",
     "selectionColor": "#19B6EE",
     "backgroundColor": "#111111",

--- a/qml/keys/ActionKey.qml
+++ b/qml/keys/ActionKey.qml
@@ -17,7 +17,6 @@
 import QtQuick 2.4
 
 import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.0
 
 import MaliitKeyboard 2.0
 
@@ -26,10 +25,6 @@ CharKey {
     property string iconNormal: ""
     property string iconShifted: ""
     property string iconCapsLock: ""
-
-    property string iconSourceNormal: ""
-    property string iconSourceShifted: ""
-    property string iconSourceCapsLock: ""
 
     noMagnifier: true
     skipAutoCaps: true
@@ -56,24 +51,14 @@ CharKey {
         height: panel.keyHeight
         width: parent.width
 
-        Image {
+        KeyIcon {
             id: iconImage
-            source: iconSourceNormal !== "" ? iconSourceNormal
-                                            : iconNormal ? Theme.iconsPath + "/%1.png".arg(iconNormal)
-                                                         : ""
-            property color color: actionKeyRoot.colorNormal
+            name: iconNormal
+            color: actionKeyRoot.colorNormal
             anchors.centerIn: parent
             anchors.verticalCenterOffset: -actionKeyRoot.rowMargin / 2 - Device.gu(0.15)
             height: actionKeyRoot.fontSize
-            fillMode: Image.PreserveAspectFit
-            visible: false
-        }
-        ColorOverlay {
-            cached: true
-            anchors.fill: iconImage
-            source: iconImage
-            color: iconImage.color
-            visible: (label == "" && !panel.hideKeyLabels)
+            width: height
         }
     }
 
@@ -84,9 +69,7 @@ CharKey {
             name: "SHIFTED"
             PropertyChanges {
                 target: iconImage
-                source: iconSourceShifted !== "" ? iconSourceShifted 
-                                                 : iconShifted ? Theme.iconsPath + "/%1.png".arg(iconShifted)
-                                                               : ""
+                name: iconShifted
                 color: actionKeyRoot.colorShifted
             }
         },
@@ -94,9 +77,7 @@ CharKey {
             name: "CAPSLOCK"
             PropertyChanges {
                 target: iconImage
-                source: iconSourceCapsLock !== "" ? iconSourceCapsLock
-                                                  : iconCapsLock ? Theme.iconsPath + "/%1.png".arg(iconCapsLock)
-                                                                : ""
+                name: iconCapsLock
                 color: actionKeyRoot.colorCapsLock
             }
         }

--- a/qml/keys/BackspaceKey.qml
+++ b/qml/keys/BackspaceKey.qml
@@ -17,8 +17,8 @@
 import QtQuick 2.4
 
 ActionKey {
-    iconNormal: "erase";
-    iconShifted: "erase";
-    iconCapsLock: "erase";
+    iconNormal: "edit-clear";
+    iconShifted: "edit-clear";
+    iconCapsLock: "edit-clear";
     action: "backspace";
 }

--- a/qml/keys/KeyIcon.qml
+++ b/qml/keys/KeyIcon.qml
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Rodney Dawes
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import QtQuick 2.9
+import QtGraphicalEffects 1.0
+
+import MaliitKeyboard 2.0
+
+Item {
+    id: iconRoot
+
+    property string name
+
+    property alias color: iconOverlay.color
+
+    property alias source: iconImage.source
+
+    Connections {
+        target: Theme
+        onThemeChanged: {
+            // Update the sources to try and force a redraw
+            iconOverlay.source = undefined;
+            iconImage.source = iconRoot.source;
+            iconOverlay.source = iconImage;
+        }
+    }
+
+    Image {
+        id: iconImage
+        source: iconRoot.name ? "image://icon/%1".arg(iconRoot.name) : ""
+        sourceSize.width: width
+        sourceSize.height: height
+        anchors.fill: parent
+        fillMode: Image.PreserveAspectFit
+        cache: false
+        visible: false
+    }
+    ColorOverlay {
+        id: iconOverlay
+        cached: iconImage.cache
+        anchors.fill: iconImage
+        source: iconImage
+        visible: iconRoot.visible
+    }
+}

--- a/qml/keys/ShiftKey.qml
+++ b/qml/keys/ShiftKey.qml
@@ -19,9 +19,9 @@ import QtQuick 2.4
 import MaliitKeyboard 2.0
 
 ActionKey {
-    iconSourceNormal: Theme.imagesPath + "/keyboard-caps-disabled.svg"
-    iconSourceShifted: Theme.imagesPath + "/keyboard-caps-enabled.svg"
-    iconSourceCapsLock: Theme.imagesPath + "/keyboard-caps-locked.svg"
+    iconNormal: "keyboard-caps-disabled"
+    iconShifted: "keyboard-caps-enabled"
+    iconCapsLock: "keyboard-caps-locked"
 
     action: "shift"
 

--- a/src/plugin/iconprovider.cpp
+++ b/src/plugin/iconprovider.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021 Rodney Dawes
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * Neither the name of Nokia Corporation nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#include "iconprovider.h"
+
+#include <QDebug>
+#include <QGuiApplication>
+#include <QIcon>
+#include <QObject>
+
+namespace MaliitKeyboard
+{
+
+IconProvider::IconProvider(Theme* theme)
+    : QQuickImageProvider(QQuickImageProvider::Pixmap)
+    , m_theme(theme)
+{
+    // Append our icons dir as a fallback theme search path
+    auto fallbacks = QIcon::fallbackSearchPaths();
+    fallbacks.append(MALIIT_KEYBOARD_DATA_DIR "/icons");
+    QIcon::setFallbackSearchPaths(fallbacks);
+
+    // Get the app instance to be able to handle layout direction changes
+    static auto app = dynamic_cast<QGuiApplication*>(QGuiApplication::instance());
+    if (app == nullptr) {
+        qCritical() << "Failed to acquire application instance.";
+    } else {
+        QObject::connect(app, &QGuiApplication::layoutDirectionChanged,
+                         [this](Qt::LayoutDirection direction) {
+                             updateLayoutDirection(direction);
+                         });
+    }
+
+    // Connect to theme change so we ensure we grab the correct icons
+    QObject::connect(m_theme, &Theme::themeChanged,
+                     [this]() {
+                         updateThemeName();
+                     });
+}
+
+QPixmap IconProvider::requestPixmap(const QString& id,
+                                    QSize* size,
+                                    const QSize& requestedSize)
+{
+    // Ensure we have the correct theme set.
+    updateThemeName();
+
+    // Append "-rtl" if using RTL layout, so we use correct icons
+    auto name = m_layoutDirection == Qt::RightToLeft ? id + QStringLiteral("-rtl") : id;
+    auto parts = name.split(QLatin1Char('-'));
+    auto icon = QIcon::fromTheme(name);
+    while (icon.isNull() && parts.length() > 0) {
+        parts.removeLast();
+        icon = QIcon::fromTheme(parts.join(QChar('-')));
+    }
+    if (icon.isNull()) {
+        qCritical() << "Keyboard icon not found in theme.";
+        return QPixmap();
+    }
+
+    // Grab the pixmap, set the outbound size, and return the pixmap
+    auto pixmap = icon.pixmap(requestedSize);
+    if (size) {
+        *size = pixmap.size();
+    }
+    return pixmap;
+}
+
+void IconProvider::updateLayoutDirection(Qt::LayoutDirection direction)
+{
+    m_layoutDirection = direction;
+}
+
+void IconProvider::updateThemeName()
+{
+    if (QIcon::themeName() != m_theme->iconTheme()) {
+        QIcon::setThemeName(m_theme->iconTheme());
+    }
+}
+
+}

--- a/src/plugin/iconprovider.h
+++ b/src/plugin/iconprovider.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 Rodney Dawes
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list
+ * of conditions and the following disclaimer in the documentation and/or other materials
+ * provided with the distribution.
+ * Neither the name of Nokia Corporation nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef ICONPROVIDER_H
+#define ICONPROVIDER_H
+
+#include "theme.h"
+
+#include <QQuickImageProvider>
+
+namespace MaliitKeyboard
+{
+
+class IconProvider: public QQuickImageProvider
+{
+public:
+    IconProvider(Theme* theme);
+    ~IconProvider() = default;
+    QPixmap  requestPixmap(const QString& id,
+                           QSize* size,
+                           const QSize& requestedSize) override;
+
+
+private:
+    void updateLayoutDirection(Qt::LayoutDirection direction);
+    void updateThemeName();
+
+    Qt::LayoutDirection m_layoutDirection;
+    Theme* m_theme;
+};
+
+}
+
+#endif // ICONPROVIDER_H

--- a/src/plugin/inputmethod_p.h
+++ b/src/plugin/inputmethod_p.h
@@ -21,6 +21,7 @@
 #include "editor.h"
 #include "feedback.h"
 #include "greeterstatus.h"
+#include "iconprovider.h"
 #include "keyboardgeometry.h"
 #include "keyboardsettings.h"
 #include "theme.h"
@@ -95,6 +96,7 @@ public:
     std::unique_ptr<Feedback> m_feedback;
     std::unique_ptr<Theme> m_theme;
     std::unique_ptr<Device> m_device;
+    std::unique_ptr<IconProvider> m_iconProvider;
 
     WordRibbon* wordRibbon;
 
@@ -126,6 +128,7 @@ public:
         , m_feedback(std::make_unique<Feedback>(&m_settings))
         , m_theme(std::make_unique<Theme>(&m_settings))
         , m_device(std::make_unique<Device>(&m_settings))
+        , m_iconProvider(std::make_unique<IconProvider>(m_theme.get()))
         , wordRibbon(new WordRibbon)
         , previous_position(-1)
     {
@@ -187,6 +190,9 @@ public:
         }
 
         setContextProperties(engine->rootContext());
+
+        // Add our image provider for handling icon themes
+        engine->addImageProvider(QLatin1String("icon"), m_iconProvider.get());
 
         // workaround: resizeMode not working in current qpa imlementation
         // http://qt-project.org/doc/qt-5.0/qtquick/qquickview.html#ResizeMode-enum

--- a/src/plugin/theme.cpp
+++ b/src/plugin/theme.cpp
@@ -48,16 +48,13 @@ Theme::Theme(const KeyboardSettings *settings, QObject *parent)
 
 Theme::~Theme() = default;
 
-QUrl Theme::iconsPath() const
+QString Theme::iconTheme() const
 {
-    if (m_themeData.contains("iconsDir")) {
-        const auto &icons = m_themeData.value("iconsDir").toString();
-        if (QFileInfo(icons).isRelative())
-            return QUrl().resolved(icons);
-        return QUrl::fromLocalFile(icons);
+    if (m_themeData.contains("iconTheme")) {
+        return m_themeData.value("iconTheme").toString();
     }
 
-    return QUrl::fromLocalFile(MALIIT_KEYBOARD_DATA_DIR "/icons");
+    return QStringLiteral();
 }
 
 QUrl Theme::imagesPath() const

--- a/src/plugin/theme.h
+++ b/src/plugin/theme.h
@@ -40,7 +40,7 @@ class Theme : public QObject
 {
     Q_OBJECT
 
-    Q_PROPERTY(QUrl iconsPath READ iconsPath NOTIFY themeChanged)
+    Q_PROPERTY(QString iconTheme READ iconTheme NOTIFY themeChanged)
     Q_PROPERTY(QUrl imagesPath READ imagesPath NOTIFY themeChanged)
 
     Q_PROPERTY(QColor fontColor READ fontColor NOTIFY themeChanged)
@@ -65,7 +65,7 @@ public:
     explicit Theme(const KeyboardSettings *settings, QObject *parent = nullptr);
     ~Theme() override;
 
-    [[nodiscard]] QUrl iconsPath() const;
+    [[nodiscard]] QString iconTheme() const;
     [[nodiscard]] QUrl imagesPath() const;
 
     [[nodiscard]] QColor fontColor() const;


### PR DESCRIPTION
This needs https://invent.kde.org/frameworks/breeze-icons/-/merge_requests/121 for the icons to work with the Breeze themes, or https://gitlab.com/ubports/core/suru-icon-theme installed (may be available in some distributions already) for the other themes.