### PR TITLE
Remove label from language key on emoji keyboard

### DIFF
--- a/plugins/emoji/qml/Keyboard_emoji.qml
+++ b/plugins/emoji/qml/Keyboard_emoji.qml
@@ -219,8 +219,6 @@ KeyPad {
 
         LanguageKey {
             id: languageMenuButton
-            label: "ABC"
-            shifted: label
             normalColor: Theme.backgroundColor
             borderColor: normalColor
             pressedColor: Theme.backgroundColor


### PR DESCRIPTION
With icon theme support, it seems the language key on the emoji layout
is now sowing both text and icon overlapped. As 'ABC' is untranslated
and doesn't make sense to have for many languages, just remove the
label from it, and rely on the language icon instead.