### PR TITLE
Set haptic feedback duration to 100ms and intensity to 0.5

### DIFF
--- a/src/plugin/feedback.cpp
+++ b/src/plugin/feedback.cpp
@@ -54,8 +54,8 @@ Feedback::Feedback(const KeyboardSettings *settings)
 #ifdef HAVE_QT5_FEEDBACK
     m_pressEffect->setAttackIntensity(0.0);
     m_pressEffect->setAttackTime(50);
-    m_pressEffect->setIntensity(1.0);
-    m_pressEffect->setDuration(150);
+    m_pressEffect->setIntensity(0.5);
+    m_pressEffect->setDuration(100);
     m_pressEffect->setFadeTime(50);
     m_pressEffect->setFadeIntensity(0.0);
 #endif


### PR DESCRIPTION
Currently vibrations are far too long and strong on all devices I've tested (OP6, Pinephone, Pinephone Pro), and get mixed up with other keypresses. 100ms is the shortest duration that the Pinephone can actually register. While a much lower duration would be optimal for other devices (Pinephone Pro, Oneplus 6), this strikes a balance for now so that every device can have vibration effects.

In the future, we really need some facility in order to define vibration profiles for each device, since motors can vary wildly.