### PR TITLE
Build with C++14 when presage is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,8 @@ set(maliit-keyboard-definitions HUNSPELL_DICT_PATH="${HUNSPELL_DICT_PATH}"
 set(maliit-keyboard-include-dirs)
 
 if(enable-presage)
+    # Presage headers incompatible with C++17, which is default in newer GCC
+    set(CMAKE_CXX_STANDARD 14)
     find_package(Presage REQUIRED)
 
     if(Presage_FOUND)


### PR DESCRIPTION
As newer GCC versions default to C++17 and presage headers are not
compatible, we need to specify an older standard, to compile