### PR TITLE
Fixes for spell checking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT DEFINED QT5_QML_INSTALL_DIR)
             "Installation directory for Qt 5 QML plugins [LIB_INSTALL_DIR/qt5/qml]")
 endif()
 
-set(HUNSPELL_DICT_PATH "/usr/share/myspell" CACHE PATH "Directory containing hunspell dictionary files")
+set(HUNSPELL_DICT_PATH "/usr/share/hunspell" CACHE PATH "Directory containing hunspell dictionary files")
 set(MALIIT_KEYBOARD_QML_DIR "${CMAKE_INSTALL_LIBDIR}/maliit/keyboard2/qml" CACHE PATH "Directory containing maliit-keyboard QML files")
 set(MALIIT_KEYBOARD_DATA_DIR "${CMAKE_INSTALL_DATADIR}/maliit/keyboard2" CACHE PATH "Directory containing maliit-keyboard data files")
 set(MALIIT_KEYBOARD_LANGUAGES_DIR "${CMAKE_INSTALL_LIBDIR}/maliit/keyboard2/languages" CACHE PATH "Directory containing maliit-keyboard data")

--- a/qml/WordRibbon.qml
+++ b/qml/WordRibbon.qml
@@ -26,11 +26,6 @@ Rectangle {
     objectName: "wordRibbenCanvas"
     state: "NORMAL"
 
-    Rectangle {
-        anchors.fill: parent
-        color: Theme.backgroundColor
-    }
-
     ListView {
         id: listView
         objectName: "wordListView"
@@ -94,17 +89,16 @@ Rectangle {
             name: "NORMAL"
             PropertyChanges {
                 target: wordRibbonCanvas
-                color: "transparent"
+                color: Theme.backgroundColor
             }
         },
         State {
             name: "SELECTED"
             PropertyChanges {
                 target: wordRibbonCanvas
-                color: "#e4e4e4"
+                color: Theme.actionKeyPressedColor
             }
         }
     ]
 
 }
-


### PR DESCRIPTION
For some reason, the maliit fork was defaulting to myspell dictionaries path, rather than hunspell, so correct that. Also removes an extraneous rectangle in the word ribbon, which prevented the active press visual feedback through state changes, and uses the correct colors from the selected theme.