### PR TITLE
Allow disabling show/hide animations with an environment variable

### DIFF
--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -219,7 +219,10 @@ Item {
 
         PropertyAnimation {
             id: bounceBackAnimation
-            target: keyboardSurface
+            // Animations don't have an "enabled" property, so just set the
+            // target to null if animation is disabled, which effectively also
+            // disables the animation.
+            target: maliit_input_method.animationEnabled ? keyboardSurface : null
             properties: "y"
             easing.type: Easing.OutBounce;
             easing.overshoot: 2.0
@@ -267,6 +270,7 @@ Item {
             }
         ]
         transitions: Transition {
+            enabled: maliit_input_method.animationEnabled
             NumberAnimation { target: keyboardSurface; properties: "y"; duration: 165}
         }
 

--- a/src/plugin/inputmethod.cpp
+++ b/src/plugin/inputmethod.cpp
@@ -134,6 +134,12 @@ InputMethod::InputMethod(MAbstractInputMethodHost *host)
     // settings to be initialized first:
     d->setLayoutOrientation(d->appsCurrentOrientation);
 
+    // If MALIIT_ENABLE_ANIMATIONS environment is set and 0, disable animations,
+    // otherwise enable them.
+    bool animationOk = false;
+    int animationEnv = qEnvironmentVariableIntValue("MALIIT_ENABLE_ANIMATIONS", &animationOk);
+    d->animationEnabled = animationOk && animationEnv != 0;
+
     QString prefix = qgetenv("KEYBOARD_PREFIX_PATH");
     if (!prefix.isEmpty()) {
         d->view->setSource(QUrl::fromLocalFile(prefix + QDir::separator() + g_maliit_keyboard_qml));
@@ -739,6 +745,12 @@ QString InputMethod::surroundingRight()
 {
     Q_D(InputMethod);
     return d->editor.text()->surroundingRight();
+}
+
+bool InputMethod::isAnimationEnabled() const
+{
+    Q_D(InputMethod);
+    return d->animationEnabled;
 }
 
 bool InputMethod::languageIsSupported(const QString plugin) {

--- a/src/plugin/inputmethod.h
+++ b/src/plugin/inputmethod.h
@@ -65,6 +65,7 @@ class InputMethod
     Q_PROPERTY(QString theme READ theme NOTIFY themeChanged)
     Q_PROPERTY(QString surroundingLeft READ surroundingLeft)
     Q_PROPERTY(QString surroundingRight READ surroundingRight)
+    Q_PROPERTY(bool animationEnabled READ isAnimationEnabled CONSTANT)
 
 public:
     /// Same as Maliit::TextContentType but usable in QML
@@ -143,6 +144,8 @@ public:
 
     QString surroundingLeft();
     QString surroundingRight();
+
+    bool isAnimationEnabled() const;
 
     Q_SLOT void close();
 

--- a/src/plugin/inputmethod_p.h
+++ b/src/plugin/inputmethod_p.h
@@ -107,6 +107,8 @@ public:
     QStringList languagesPaths;
     QString currentPluginPath;
 
+    bool animationEnabled = true;
+
     explicit InputMethodPrivate(InputMethod * const _q,
                                 MAbstractInputMethodHost *host)
         : q(_q)


### PR DESCRIPTION
Currently, the animation for showing or hiding the keyboard is done
client side. This leads to some nasty race conditions, at least on KWin
Wayland, because the keyboard rect is sent asynchronously and any window
geometry changes it causes are also async.

To allow the animation to be done by the compositor directly, we first
need to disable the client-side animation.