### PR TITLE
Improve layout switching behavior

### DIFF
--- a/data/schemas/org.maliit.keyboard.maliit.gschema.xml
+++ b/data/schemas/org.maliit.keyboard.maliit.gschema.xml
@@ -6,11 +6,6 @@
       <description>Currently active language, selected by user in the keyboard language menu</description>
       <default>'en'</default>
     </key>
-    <key name="previous-language" type="s">
-      <summary>Previous language</summary>
-      <description>Language which was in use immediately prior to the current active language</description>
-      <default>''</default>
-    </key>
     <key name="enabled-languages" type="as">
       <summary>Enabled languages</summary>
       <description>User-defined list of activatable languages.</description>

--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -253,12 +253,6 @@ Item {
                     maliit_input_method.close();
                     canvas.hidingComplete = true;
                     reportKeyboardVisibleRect();
-                    // Switch back to the previous layout if we're in
-                    // in a layout like emoji that requests switchBack
-                    if (keypad.switchBack && maliit_input_method.previousLanguage) {
-                        keypad.switchBack = false;
-                        maliit_input_method.activeLanguage = maliit_input_method.previousLanguage;
-                    }
                     
                     // Exit cursor swipe mode when the keyboard hides
                     fullScreenItem.exitSwipeMode();

--- a/qml/KeyboardContainer.qml
+++ b/qml/KeyboardContainer.qml
@@ -31,7 +31,6 @@ Item {
 
     property string activeKeypadState: "NORMAL"
     property alias popoverEnabled: extendedKeysSelector.enabled
-    property bool switchBack: false // Switch back to the previous layout when changing fields
     property bool hideKeyLabels: false // Hide key labels when in cursor movement mode
 
     property Item lastKeyPressed // Used for determining double click validity in PressArea

--- a/qml/keys/LanguageKey.qml
+++ b/qml/keys/LanguageKey.qml
@@ -47,7 +47,6 @@ ActionKey {
     }
 
     onReleased: {
-        panel.switchBack = false;
         if (held) {
             return;
         }

--- a/qml/keys/LanguageKey.qml
+++ b/qml/keys/LanguageKey.qml
@@ -52,8 +52,8 @@ ActionKey {
             return;
         }
 
-        if (maliit_input_method.previousLanguage && maliit_input_method.previousLanguage != maliit_input_method.activeLanguage) {
-            maliit_input_method.activeLanguage = maliit_input_method.previousLanguage
+        if (altLangs) {
+            Keyboard.selectNextLanguage();
         } else {
             keypad.state = "EMOJI"
         }

--- a/src/plugin/inputmethod.cpp
+++ b/src/plugin/inputmethod.cpp
@@ -119,7 +119,6 @@ InputMethod::InputMethod(MAbstractInputMethodHost *host)
     d->registerAutoCapsSetting();
     d->registerWordEngineSetting();
     d->registerActiveLanguage();
-    d->registerPreviousLanguage();
     d->registerEnabledLanguages();
     d->registerDoubleSpaceFullStop();
     d->registerStayHidden();
@@ -341,9 +340,6 @@ void InputMethod::onEnabledLanguageSettingsChanged()
 {
     Q_D(InputMethod);
     d->enabledLanguages = d->m_settings.enabledLanguages();
-    if (!d->enabledLanguages.contains(d->previousLanguage)) {
-        setPreviousLanguage(QString());
-    }
     Q_EMIT enabledLanguagesChanged(d->enabledLanguages);
 }
 
@@ -543,14 +539,6 @@ const QString &InputMethod::activeLanguage() const
     return d->activeLanguage;
 }
 
-//! \brief InputMethod::previousLanguage returns the language that was used
-//! immediately prior to the current activeLanguage
-const QString &InputMethod::previousLanguage() const
-{
-    Q_D(const InputMethod);
-    return d->previousLanguage;
-}
-
 //! \brief InputMethod::useAudioFeedback is true, when keys should play a audio
 //! feedback when pressed
 //! \return
@@ -631,7 +619,6 @@ void InputMethod::setActiveLanguage(const QString &newLanguage)
 
     d->editor.commitPreedit();
 
-    setPreviousLanguage(d->activeLanguage);
     d->activeLanguage = newLanguage;
     d->host->setLanguage(newLanguage);
     d->m_settings.setActiveLanguage(newLanguage);
@@ -639,23 +626,6 @@ void InputMethod::setActiveLanguage(const QString &newLanguage)
     qDebug() << "in inputMethod.cpp setActiveLanguage() emitting activeLanguageChanged to" << d->activeLanguage;
     Q_EMIT activeLanguageChanged(d->activeLanguage);
 }
-
-//! \brief InputMethod::setPreviousLanguage
-//! Set the language used immediately prior to the current active language.
-//! \param prevLanguage id the previous language used. e.g. "en" or "emoji"
-void InputMethod::setPreviousLanguage(const QString &prevLanguage)
-{
-    Q_D(InputMethod);
-
-    if (d->previousLanguage == prevLanguage)
-        return;
-
-    d->previousLanguage = prevLanguage;
-    d->m_settings.setPreviousLanguage(prevLanguage);
-
-    Q_EMIT previousLanguageChanged(d->previousLanguage);
-}
-
 
 void InputMethod::onWordEnginePluginChanged()
 {

--- a/src/plugin/inputmethod.cpp
+++ b/src/plugin/inputmethod.cpp
@@ -596,6 +596,18 @@ const QString InputMethod::audioFeedbackSound() const
     return d->m_settings.keyPressAudioFeedbackSound();
 }
 
+//! \brief InputMethod::selectNextLanguage
+//! Sets the active language to the next language in the enaabled languages list
+void InputMethod::selectNextLanguage()
+{
+    auto const& langs = enabledLanguages();
+    if (activeLanguage() == langs.back()) {
+        setActiveLanguage(langs.front());
+    } else {
+        setActiveLanguage(langs[langs.indexOf(activeLanguage()) + 1]);
+    }
+}
+
 //! \brief InputMethod::setActiveLanguage
 //! Sets the currently active/used language
 //! \param newLanguage id of the new language. For example "en" or "es"

--- a/src/plugin/inputmethod.cpp
+++ b/src/plugin/inputmethod.cpp
@@ -340,6 +340,11 @@ void InputMethod::onEnabledLanguageSettingsChanged()
 {
     Q_D(InputMethod);
     d->enabledLanguages = d->m_settings.enabledLanguages();
+    // Switch to first language in enabled languages if the currently active
+    // language is no longer enabled
+    if (!d->enabledLanguages.contains(d->activeLanguage)) {
+        setActiveLanguage(d->enabledLanguages.front());
+    }
     Q_EMIT enabledLanguagesChanged(d->enabledLanguages);
 }
 

--- a/src/plugin/inputmethod.h
+++ b/src/plugin/inputmethod.h
@@ -114,6 +114,7 @@ public:
     const QStringList &enabledLanguages() const;
 
     const QString &activeLanguage() const;
+    Q_INVOKABLE void selectNextLanguage();
     Q_SLOT void setActiveLanguage(const QString& newLanguage);
 
     const QString &previousLanguage() const;

--- a/src/plugin/inputmethod.h
+++ b/src/plugin/inputmethod.h
@@ -51,7 +51,6 @@ class InputMethod
     Q_PROPERTY(TextContentType contentType READ contentType WRITE setContentType NOTIFY contentTypeChanged)
     Q_PROPERTY(QStringList enabledLanguages READ enabledLanguages NOTIFY enabledLanguagesChanged)
     Q_PROPERTY(QString activeLanguage READ activeLanguage WRITE setActiveLanguage NOTIFY activeLanguageChanged)
-    Q_PROPERTY(QString previousLanguage READ previousLanguage WRITE setPreviousLanguage NOTIFY previousLanguageChanged)
     Q_PROPERTY(QObject* actionKeyOverride READ actionKeyOverride NOTIFY actionKeyOverrideChanged)
     Q_PROPERTY(bool useHapticFeedback READ useHapticFeedback NOTIFY useHapticFeedbackChanged)
     Q_PROPERTY(bool enableMagnifier READ enableMagnifier NOTIFY enableMagnifierChanged)
@@ -117,9 +116,6 @@ public:
     Q_INVOKABLE void selectNextLanguage();
     Q_SLOT void setActiveLanguage(const QString& newLanguage);
 
-    const QString &previousLanguage() const;
-    Q_SLOT void setPreviousLanguage(const QString& prevLanguage);
-
     Q_SLOT void onVisibleRectChanged();
 
     bool useAudioFeedback() const;
@@ -163,7 +159,6 @@ Q_SIGNALS:
     void deactivateAutocaps();
     void enabledLanguagesChanged(QStringList languages);
     void activeLanguageChanged(QString language);
-    void previousLanguageChanged(QString language);
     void useAudioFeedbackChanged();
     void audioFeedbackSoundChanged(QString sound);
     void useHapticFeedbackChanged();

--- a/src/plugin/inputmethod_p.h
+++ b/src/plugin/inputmethod_p.h
@@ -82,7 +82,6 @@ public:
     bool wordEngineEnabled;
     InputMethod::TextContentType contentType;
     QString activeLanguage;
-    QString previousLanguage;
     QStringList enabledLanguages;
     Qt::ScreenOrientation appsCurrentOrientation;
     QString keyboardState;
@@ -120,7 +119,6 @@ public:
         , wordEngineEnabled(false)
         , contentType(InputMethod::FreeTextContentType)
         , activeLanguage(QStringLiteral("en"))
-        , previousLanguage()
         , enabledLanguages(activeLanguage)
         , appsCurrentOrientation(qGuiApp->primaryScreen()->orientation())
         , keyboardState(QStringLiteral("CHARACTERS"))
@@ -303,15 +301,6 @@ public:
         activeLanguage = m_settings.activeLanguage();
         qDebug() << "inputmethod_p.h registerActiveLanguage(): activeLanguage is:" << activeLanguage;
         q->setActiveLanguage(activeLanguage);
-    }
-
-    void registerPreviousLanguage()
-    {
-        QObject::connect(&m_settings, &MaliitKeyboard::KeyboardSettings::previousLanguageChanged,
-                         q, &InputMethod::setPreviousLanguage);
-
-        previousLanguage = m_settings.previousLanguage();
-        q->setPreviousLanguage(previousLanguage);
     }
 
     void registerEnabledLanguages()

--- a/src/plugin/keyboardsettings.cpp
+++ b/src/plugin/keyboardsettings.cpp
@@ -35,7 +35,6 @@
 using namespace MaliitKeyboard;
 
 const QLatin1String ACTIVE_LANGUAGE_KEY = QLatin1String("activeLanguage");
-const QLatin1String PREVIOUS_LANGUAGE_KEY = QLatin1String("previousLanguage");
 const QLatin1String ENABLED_LANGUAGES_KEY = QLatin1String("enabledLanguages");
 const QLatin1String AUTO_CAPITALIZATION_KEY = QLatin1String("autoCapitalization");
 const QLatin1String AUTO_COMPLETION_KEY = QLatin1String("autoCompletion");
@@ -81,13 +80,6 @@ KeyboardSettings::KeyboardSettings(QObject *parent) :
     if (activeLanguage() == emoji) {
         setActiveLanguage(enabled[0]);
     }
-    if (previousLanguage() == emoji) {
-        if (enabled.length() > 1) {
-            setPreviousLanguage(enabled.back());
-        } else {
-            setPreviousLanguage(QLatin1String(""));
-        }
-    }
 }
 
 /*!
@@ -103,22 +95,6 @@ QString KeyboardSettings::activeLanguage() const
 void KeyboardSettings::setActiveLanguage(const QString& id)
 {
     m_settings->set(ACTIVE_LANGUAGE_KEY, QVariant(id));
-}
-
-/*!
- * \brief KeyboardSettings::previousLanguage returns the language that was 
- * active immediately before the current one.
- * \return previously language
- */
-
-QString KeyboardSettings::previousLanguage() const
-{
-    return m_settings->get(PREVIOUS_LANGUAGE_KEY).toString();
-}
-
-void KeyboardSettings::setPreviousLanguage(const QString& id)
-{
-    m_settings->set(PREVIOUS_LANGUAGE_KEY, QVariant(id));
 }
 
 /*!
@@ -270,9 +246,6 @@ void KeyboardSettings::settingUpdated(const QString &key)
 {
     if (key == ACTIVE_LANGUAGE_KEY) {
         Q_EMIT activeLanguageChanged(activeLanguage());
-        return;
-    } else if (key == PREVIOUS_LANGUAGE_KEY) {
-        Q_EMIT previousLanguageChanged(previousLanguage());
         return;
     } else if (key == ENABLED_LANGUAGES_KEY) {
         Q_EMIT enabledLanguagesChanged(enabledLanguages());

--- a/src/plugin/keyboardsettings.cpp
+++ b/src/plugin/keyboardsettings.cpp
@@ -72,10 +72,7 @@ KeyboardSettings::KeyboardSettings(QObject *parent) :
     auto enabled = enabledLanguages();
     if (enabled.contains(emoji)) {
         enabled.removeAll(emoji);
-        if (enabled.isEmpty()) {
-            enabled << QLatin1String("en");
-        }
-        m_settings->set(ENABLED_LANGUAGES_KEY, enabled);
+        setEnabledLanguages(enabled);
     }
     if (activeLanguage() == emoji) {
         setActiveLanguage(enabled[0]);
@@ -97,6 +94,11 @@ void KeyboardSettings::setActiveLanguage(const QString& id)
     m_settings->set(ACTIVE_LANGUAGE_KEY, QVariant(id));
 }
 
+void KeyboardSettings::resetActiveLanguage()
+{
+    m_settings->reset(ACTIVE_LANGUAGE_KEY);
+}
+
 /*!
  * \brief KeyboardSettings::enabledLanguages returns a list of languages that are
  * active
@@ -105,6 +107,20 @@ void KeyboardSettings::setActiveLanguage(const QString& id)
 QStringList KeyboardSettings::enabledLanguages() const
 {
     return m_settings->get(ENABLED_LANGUAGES_KEY).toStringList();
+}
+
+void KeyboardSettings::setEnabledLanguages(const QStringList& ids)
+{
+    if (ids.isEmpty()) {
+        resetEnabledLanguages();
+        return;
+    }
+    m_settings->set(ENABLED_LANGUAGES_KEY, ids);
+}
+
+void KeyboardSettings::resetEnabledLanguages()
+{
+    m_settings->reset(ENABLED_LANGUAGES_KEY);
 }
 
 /*!

--- a/src/plugin/keyboardsettings.h
+++ b/src/plugin/keyboardsettings.h
@@ -45,7 +45,10 @@ public:
     
     QString activeLanguage() const;
     void setActiveLanguage(const QString& id);
+    void resetActiveLanguage();
     QStringList enabledLanguages() const;
+    void setEnabledLanguages(const QStringList& ids);
+    void resetEnabledLanguages();
     bool autoCapitalization() const;
     bool autoCompletion() const;
     bool predictiveText() const;

--- a/src/plugin/keyboardsettings.h
+++ b/src/plugin/keyboardsettings.h
@@ -45,8 +45,6 @@ public:
     
     QString activeLanguage() const;
     void setActiveLanguage(const QString& id);
-    QString previousLanguage() const;
-    void setPreviousLanguage(const QString& id);
     QStringList enabledLanguages() const;
     bool autoCapitalization() const;
     bool autoCompletion() const;
@@ -66,7 +64,6 @@ public:
 
 Q_SIGNALS:
     void activeLanguageChanged(QString);
-    void previousLanguageChanged(QString);
     void enabledLanguagesChanged(QStringList);
     void autoCapitalizationChanged(bool);
     void autoCompletionChanged(bool);


### PR DESCRIPTION
This makes switching layouts much less confusing now, behaving more like the keyboards on other modern OSes, by simply cycling through all the enabled layouts.