### PR TITLE
Enable anthy-unicode build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(Qt5Multimedia)
 find_package(Qt5Feedback)
 find_package(Intl REQUIRED)
 
+find_package(AnthyUnicode)
 find_package(Anthy)
 find_package(Pinyin)
 find_package(Chewing)
@@ -353,7 +354,13 @@ abstract_language_plugin(en@dv englishdvorak
 abstract_language_plugin(fr-ch french LIBRARIES westernsupport)
 abstract_language_plugin(th thai DIRECTORY qml/keys)
 
-if(Anthy_FOUND)
+if(AnthyUnicode_FOUND)
+    abstract_language_plugin(ja japanese ABSTRACT_LANGUAGE_PLUGIN
+            SOURCES anthyadapter.cpp anthyadapter.h
+            LIBRARIES ${AnthyUnicode_LIBRARIES}
+            INCLUDE_DIRS ${AnthyUnicode_INCLUDE_DIRS}
+            DIRECTORY qml/keys)
+elseif(Anthy_FOUND)
     abstract_language_plugin(ja japanese ABSTRACT_LANGUAGE_PLUGIN
             SOURCES anthyadapter.cpp anthyadapter.h
             LIBRARIES ${Anthy_LIBRARIES}

--- a/cmake/FindAnthyUnicode.cmake
+++ b/cmake/FindAnthyUnicode.cmake
@@ -1,0 +1,14 @@
+include(FeatureSummary)
+set_package_properties(anthyunicode PROPERTIES
+        URL "https://github.com/fujiwarat/anthy-unicode"
+        DESCRIPTION "Anthy provides the library to input Japanese on the applications.")
+
+find_package(PkgConfig)
+pkg_check_modules(PC_AnthyUnicode QUIET anthy-unicode)
+
+find_library(AnthyUnicode_LIBRARIES NAMES anthy-unicode ${PC_AnthyUnicode_LIBRARIES} HINTS ${PC_AnthyUnicode_LIBRARY_DIRS})
+find_path(AnthyUnicode_INCLUDE_DIRS anthy/anthy.h HINTS ${PC_AnthyUnicode_INCLUDE_DIRS})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(AnthyUnicode DEFAULT_MSG AnthyUnicode_LIBRARIES AnthyUnicode_INCLUDE_DIRS)
+mark_as_advanced(AnthyUnicode_INCLUDE_DIRS AnthyUnicode_LIBRARIES)


### PR DESCRIPTION
anthy is no longer maintained currently and anthy-unicode is generated
to convert internal EUC data to UTF-8 and maintained.
If anthy-unicode package is found, it can be used instead of anthy.