### PR TITLE
qml: Adjust WordRibbon height and font size to scale better

### DIFF
--- a/qml/ActionsToolbar.qml
+++ b/qml/ActionsToolbar.qml
@@ -16,27 +16,6 @@ Rectangle{
         right: parent.right
     }
 
-    states: [
-        State {
-            name: "wordribbon"
-        
-            AnchorChanges {
-                target: actionsToolbar
-                anchors.top: undefined
-                anchors.bottom: keyboardComp.top
-            }
-        },
-        State {
-            name: "top"
-
-            AnchorChanges {
-                target: actionsToolbar
-                anchors.top: parent.top
-                anchors.bottom: undefined
-            }
-         }
-    ]
-    
     // Disable clicking behind the toolbar
     MouseArea {
         anchors.fill: parent

--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -156,10 +156,8 @@ Item {
                     id: toolbar
                     objectName: "actionsToolbar"
                     
-                    z: 1
                     visible: fullScreenItem.cursorSwipe
                     height: Device.wordRibbonHeight
-                    state: wordRibbon.visible ? "wordribbon" : "top"
                 }
                     
 

--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -148,7 +148,8 @@ Item {
                     id: wordRibbon
                     objectName: "wordRibbon"
 
-                    visible: canvas.wordribbon_visible && keypad.state !== "EMOJI"
+                    // Hide thte word ribbon when in emoji or cursor mode
+                    visible: !fullScreenItem.cursorSwipe && canvas.wordribbon_visible && keypad.state !== "EMOJI"
 
                     anchors.bottom: keyboardComp.top
                     width: parent.width;

--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -68,9 +68,6 @@ Item {
         width: parent.width
         height: fullScreenItem.height * (fullScreenItem.landscape ? Device.keyboardHeightLandscape
                                                                   : Device.keyboardHeightPortrait)
-                                      + wordRibbon.height + borderTop.height
-
-        property int keypadHeight: height;
 
         visible: true
 
@@ -98,11 +95,7 @@ Item {
 
             property int jumpBackThreshold: Device.gu(10)
 
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
-            height: (parent.height - canvas.keypadHeight) + wordRibbon.height +
-                    borderTop.height
+            anchors.fill: parent
 
             drag.target: keyboardSurface
             drag.axis: Drag.YAxis;
@@ -174,7 +167,8 @@ Item {
                     id: keyboardComp
                     objectName: "keyboardComp"
 
-                    height: canvas.keypadHeight - wordRibbon.height + keypad.anchors.topMargin
+                    visible: !fullScreenItem.cursorSwipe
+                    height: parent.height
                     width: parent.width
                     anchors.bottom: parent.bottom
 
@@ -188,20 +182,12 @@ Item {
                         color: Theme.backgroundColor
                     }
                 
-                    Item {
-                        id: borderTop
-                        width: parent.width
-                        anchors.top: parent.top.bottom
-                        height: wordRibbon.visible ? 0 : Device.top_margin
-                    }
-
                     KeyboardContainer {
                         id: keypad
 
-                        anchors.top: borderTop.bottom
-                        anchors.bottom: background.bottom
+                        anchors.fill: parent
+                        anchors.topMargin: wordRibbon.visible ? 0 : Device.top_margin
                         anchors.bottomMargin: Device.bottom_margin
-                        width: parent.width
                         hideKeyLabels: fullScreenItem.cursorSwipe
 
                         onPopoverEnabledChanged: fullScreenItem.reportKeyboardVisibleRect();

--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -153,8 +153,8 @@ Item {
                     anchors.bottom: keyboardComp.top
                     width: parent.width;
 
-                    height: canvas.wordribbon_visible ? Device.wordRibbonHeight
-                                                      : 0
+                    // Use a size proportional to the height of keyboard keys
+                    height: visible ? keypad.keyHeight * 0.5 : 0
                     onHeightChanged: fullScreenItem.reportKeyboardVisibleRect();
                 }
                 

--- a/qml/WordRibbon.qml
+++ b/qml/WordRibbon.qml
@@ -17,6 +17,7 @@
 import QtQuick 2.4
 
 import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.12
 
 import MaliitKeyboard 2.0
 
@@ -36,22 +37,24 @@ Rectangle {
         orientation: ListView.Horizontal
         delegate: wordCandidateDelegate
 
+        spacing: Device.gu(2)
     }
 
     Component {
         id: wordCandidateDelegate
-        Item {
+        RowLayout {
             id: wordCandidateItem
             // Use 1/3 of pixel height of parent converted to grid units
             // as a minimum width threshhold, so that short suggestions
             // are wide enough to tap with a thumb
             width: Math.max(Device.gu(height / 3), implicitWidth)
             height: wordRibbonCanvas.height
-            anchors.leftMargin: Device.gu(2)
-            anchors.rightMargin: Device.gu(2)
+            spacing: listView.spacing
 
             Label {
                 id: wordItem
+
+                Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
 
                 property bool textBold: isPrimaryCandidate || listView.count == 1 // Exposed for autopilot
 
@@ -77,6 +80,18 @@ Rectangle {
                         event_handler.onWordCandidateReleased(wordItem.text, isUserInput)
                     }
                 }
+            }
+
+            // FIXME: ListView doesn't support separators directly so we need
+            // to be a little hacky to add a muted separator between word
+            // candidates, so that multi-word suggestions are distinct
+            Rectangle {
+                Layout.alignment: Qt.AlignVCenter
+                width: 1
+                height: parent.height * 0.5
+                color: wordItem.color
+                opacity: 0.3
+                visible: index != listView.count - 1
             }
         }
     }

--- a/qml/WordRibbon.qml
+++ b/qml/WordRibbon.qml
@@ -37,6 +37,10 @@ Rectangle {
         orientation: ListView.Horizontal
         delegate: wordCandidateDelegate
 
+        leftMargin: Device.gu(1)
+        rightMargin: Device.gu(1)
+        topMargin: 0
+        bottomMargin: Device.top_margin
         spacing: Device.gu(2)
     }
 
@@ -55,13 +59,14 @@ Rectangle {
                 id: wordItem
 
                 Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+                Layout.fillHeight: true
 
                 property bool textBold: isPrimaryCandidate || listView.count == 1 // Exposed for autopilot
 
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
 
-                font.pixelSize: parent.height * 0.7
+                font.pixelSize: parent.height - Device.top_margin * 2
                 font.family: Theme.fontFamily
                 font.weight: textBold ? Font.Bold : Font.Light
                 text: word

--- a/qml/WordRibbon.qml
+++ b/qml/WordRibbon.qml
@@ -42,7 +42,10 @@ Rectangle {
         id: wordCandidateDelegate
         Item {
             id: wordCandidateItem
-            width: wordItem.width + Device.gu(2)
+            // Use 1/3 of pixel height of parent converted to grid units
+            // as a minimum width threshhold, so that short suggestions
+            // are wide enough to tap with a thumb
+            width: Math.max(Device.gu(height / 3), implicitWidth)
             height: wordRibbonCanvas.height
             anchors.leftMargin: Device.gu(2)
             anchors.rightMargin: Device.gu(2)

--- a/qml/WordRibbon.qml
+++ b/qml/WordRibbon.qml
@@ -16,7 +16,7 @@
 
 import QtQuick 2.4
 
-import QtQuick.Controls 2.1
+import QtQuick.Controls 2.12
 
 import MaliitKeyboard 2.0
 
@@ -44,41 +44,35 @@ Rectangle {
             id: wordCandidateItem
             width: wordItem.width + Device.gu(2)
             height: wordRibbonCanvas.height
-            anchors.margins: 0
-            property alias word_text: wordItem // For testing in Autopilot
-            property bool textBold: isPrimaryCandidate || listView.count == 1 // Exposed for autopilot
+            anchors.leftMargin: Device.gu(2)
+            anchors.rightMargin: Device.gu(2)
 
-            Item {
-                anchors.fill: parent
-                anchors.margins: {
-                    top: 0
-                    bottom: 0
-                    left: Device.gu(2)
-                    right: Device.gu(2)
-                }
+            Label {
+                id: wordItem
 
-                Label {
-                    id: wordItem
-                    font.pixelSize: Device.wordRibbonFontSize
-                    font.family: Theme.fontFamily
-                    font.weight: textBold ? Font.Bold : Font.Light
-                    text: word;
-                    anchors.centerIn: parent
-                    color: Theme.fontColor
-                }
-            }
+                property bool textBold: isPrimaryCandidate || listView.count == 1 // Exposed for autopilot
 
-            MouseArea {
-                anchors.fill: wordCandidateItem
-                onPressed: {
-                    Feedback.keyPressed();
-                    
-                    wordRibbonCanvas.state = "SELECTED"
-                    event_handler.onWordCandidatePressed(wordItem.text, isUserInput)
-                }
-                onReleased: {
-                    wordRibbonCanvas.state = "NORMAL"
-                    event_handler.onWordCandidateReleased(wordItem.text, isUserInput)
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+
+                font.pixelSize: parent.height * 0.7
+                font.family: Theme.fontFamily
+                font.weight: textBold ? Font.Bold : Font.Light
+                text: word
+                color: Theme.fontColor
+
+                MouseArea {
+                    anchors.fill: parent
+                    onPressed: {
+                        Feedback.keyPressed();
+
+                        wordRibbonCanvas.state = "SELECTED"
+                        event_handler.onWordCandidatePressed(wordItem.text, isUserInput)
+                    }
+                    onReleased: {
+                        wordRibbonCanvas.state = "NORMAL"
+                        event_handler.onWordCandidateReleased(wordItem.text, isUserInput)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Instead of getting these values from a device config, try to simply use
some values which may scale better across varying display sizes.

Fixes #36