### PR TITLE
qml: Only load emoji keyboard QML when the state is EMOJI

### DIFF
--- a/qml/KeyboardContainer.qml
+++ b/qml/KeyboardContainer.qml
@@ -63,7 +63,7 @@ Item {
         objectName: "emojiKeypadLoader"
         anchors.fill: parent
         asynchronous: true
-        visible: panel.state === "EMOJI"
+        active: panel.state === "EMOJI"
         source: "languages/Keyboard_emoji.qml"
     }
 


### PR DESCRIPTION
With the change of emoji layout to being a state instead of a plugin, the
loader was always active, causing a slight reduction in performance with
showing the keyboard when requested. This change fixes that by only loading
the emoji QML when the emoji state is requested by the user.
