### PR TITLE
Support using LayerShellQt for the input panel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ find_package(Qt5Multimedia)
 find_package(Qt5Feedback)
 find_package(Intl REQUIRED)
 
+find_package(LayerShellQt REQUIRED)
+
 find_package(AnthyUnicode)
 find_package(Anthy)
 find_package(Pinyin)
@@ -179,6 +181,8 @@ if (Qt5Feedback_FOUND)
 endif()
 target_compile_definitions(maliit-keyboard-common PRIVATE ${maliit-keyboard-definitions})
 target_compile_features(maliit-keyboard-common PRIVATE cxx_std_17)
+
+target_link_libraries(maliit-keyboard-common LayerShellQt::Interface)
 
 set(MALIIT_KEYBOARD_PLUGIN_SOURCES
         src/plugin/plugin.cpp

--- a/src/keyboard/keyboard.cpp
+++ b/src/keyboard/keyboard.cpp
@@ -30,7 +30,7 @@
 
 int main(int argc, char **argv) {
     setenv("QT_IM_MODULE", "none", true);
-    setenv("QT_WAYLAND_SHELL_INTEGRATION", "inputpanel-shell", true);
+    setenv("QT_WAYLAND_SHELL_INTEGRATION", "layer-shell;inputpanel-shell", true);
 
     QGuiApplication app(argc, argv);
 

--- a/src/plugin/inputmethod_p.h
+++ b/src/plugin/inputmethod_p.h
@@ -14,6 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "inputmethod.h"
 #include "coreutils.h"
 
@@ -33,6 +35,8 @@
 
 #include <maliit/plugins/abstractinputmethodhost.h>
 #include <maliit/plugins/abstractpluginsetting.h>
+
+#include <LayerShellQt/Window>
 
 #include <QtQuick>
 #include <QStringList>
@@ -57,6 +61,12 @@ typedef QMap<QString, SharedOverride>::const_iterator OverridesIterator;
 QQuickView *createWindow(MAbstractInputMethodHost *host)
 {
     QScopedPointer<QQuickView> view(new QQuickView);
+
+    LayerShellQt::Window *layerShell = LayerShellQt::Window::get(view.get());
+    layerShell->setLayer(LayerShellQt::Window::LayerTop);
+    layerShell->setAnchors(LayerShellQt::Window::AnchorBottom);
+    layerShell->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityOnDemand);
+    layerShell->setScope(QStringLiteral("input-panel"));
 
     QSurfaceFormat format;
     format.setAlphaBufferSize(8);


### PR DESCRIPTION
inputpanel-shell is rather limited and doesn't support things like
proper placement and sizing. Fortunately, layer-shell can be used
instead to get support for these. This adds support for using
layer-shell, prefering it over inputpanel-shell. We only need to set
some properties from the Maliit side, most of the actual magic is
taken care of by the compositor.

Most importantly, this makes it possible for the compositor to ensure
Maliit does not overlap panels while at the same time ensuring nothing
ends up out of the screen.