### PR TITLE
Allow hiding emoji keyboard feature with settings

### DIFF
--- a/data/schemas/org.maliit.keyboard.maliit.gschema.xml
+++ b/data/schemas/org.maliit.keyboard.maliit.gschema.xml
@@ -92,5 +92,10 @@
       <description>Shows the magnifier when a key is pressed.</description>
       <default>true</default>
     </key>
+    <key name="hide-emoji" type="b">
+      <summary>Hides emoji keys</summary>
+      <description>Hides the emoji keys.</description>
+      <default>false</default>
+    </key>
   </schema>
 </schemalist>

--- a/qml/keys/LanguageKey.qml
+++ b/qml/keys/LanguageKey.qml
@@ -19,19 +19,21 @@ import QtQuick 2.4
 import MaliitKeyboard 2.0
 
 ActionKey {
-    iconNormal: altLangs ? "language-chooser-symbolic" : ""
+    iconNormal: (altLangs || hideEmoji) ? "language-chooser-symbolic" : ""
     iconShifted: iconNormal
     iconCapsLock: iconNormal
 
-    label: altLangs ? "" : "☻"
+    label: (altLangs || hideEmoji) ? "" : "☻"
     shifted: label
 
-    extended: altLangs ? ["☻"] : []
+    extended: (altLangs && !hideEmoji) ? ["☻"] : []
     extendedShifted: extended
     noMagnifier: true
 
     readonly property bool altLangs: Keyboard.enabledLanguages.length > 1
     property bool held: false;
+
+    readonly property bool hideEmoji: Keyboard.hideEmojiEnabled
 
     padding: 0
 
@@ -53,7 +55,7 @@ ActionKey {
 
         if (altLangs) {
             Keyboard.selectNextLanguage();
-        } else {
+        } else if (!hideEmoji) {
             keypad.state = "EMOJI"
         }
     }

--- a/qml/keys/LanguageMenu.qml
+++ b/qml/keys/LanguageMenu.qml
@@ -43,6 +43,8 @@ Menu {
     }
     MenuItem {
         text: Gettext.qsTr("Emoji")
+        visible: !Keyboard.hideEmojiEnabled
+        height: visible ? implicitHeight : 0
         onClicked: {
             keypad.state = "EMOJI";
             canvas.languageMenu.close();

--- a/src/plugin/inputmethod.cpp
+++ b/src/plugin/inputmethod.cpp
@@ -125,6 +125,7 @@ InputMethod::InputMethod(MAbstractInputMethodHost *host)
     d->registerPluginPaths();
     d->registerOpacity();
     d->registerTheme();
+    d->registerHideEmojiSetting();
 
     //fire signal so all listeners know what active language is
     Q_EMIT activeLanguageChanged(d->activeLanguage);
@@ -756,6 +757,12 @@ bool InputMethod::isAnimationEnabled()
 {
     Q_D(InputMethod);
     return d->animationEnabled;
+}
+
+bool InputMethod::isHideEmojiEnabled() const
+{
+    Q_D(const InputMethod);
+    return d->m_settings.hideEmoji();
 }
 
 bool InputMethod::languageIsSupported(const QString plugin) {

--- a/src/plugin/inputmethod.h
+++ b/src/plugin/inputmethod.h
@@ -65,6 +65,7 @@ class InputMethod
     Q_PROPERTY(QString surroundingLeft READ surroundingLeft)
     Q_PROPERTY(QString surroundingRight READ surroundingRight)
     Q_PROPERTY(bool animationEnabled READ isAnimationEnabled NOTIFY animationEnabledChanged)
+    Q_PROPERTY(bool hideEmojiEnabled READ isHideEmojiEnabled NOTIFY hideEmojiEnabledChanged)
 
 public:
     /// Same as Maliit::TextContentType but usable in QML
@@ -144,6 +145,8 @@ public:
 
     bool isAnimationEnabled();
 
+    bool isHideEmojiEnabled() const;
+
     Q_SLOT void close();
 
     Q_INVOKABLE bool languageIsSupported(const QString plugin);
@@ -177,6 +180,7 @@ Q_SIGNALS:
     void opacityChanged(double opacity);
     void themeChanged(QString theme);
     void animationEnabledChanged();
+    void hideEmojiEnabledChanged(bool hidden);
 
 private:
     Q_SLOT void onAutoCorrectSettingChanged();

--- a/src/plugin/inputmethod_p.h
+++ b/src/plugin/inputmethod_p.h
@@ -335,6 +335,12 @@ public:
                         q, SIGNAL(themeChanged(QString)));
     }
 
+    void registerHideEmojiSetting()
+    {
+        QObject::connect(&m_settings, &MaliitKeyboard::KeyboardSettings::hideEmojiChanged,
+                        q, &InputMethod::hideEmojiEnabledChanged);
+    }
+
     void closeOskWindow()
     {
         if (!view->isVisible())

--- a/src/plugin/keyboardsettings.cpp
+++ b/src/plugin/keyboardsettings.cpp
@@ -50,6 +50,7 @@ const QLatin1String DISABLE_HEIGHT_KEY = QLatin1String("disableHeight");
 const QLatin1String PLUGIN_PATHS_KEY = QLatin1String("pluginPaths");
 const QLatin1String OPACITY_KEY = QLatin1String("opacity");
 const QLatin1String THEME_KEY = QLatin1String("theme");
+const QLatin1String HIDE_EMOJI_KEY = QLatin1String("hideEmoji");
 
 /*!
  * \brief KeyboardSettings::KeyboardSettings class to load the settings, and
@@ -254,6 +255,14 @@ QString KeyboardSettings::theme() const
 }
 
 /*!
+ * \brief KeyboardSettings::hideEmoji returns true if the emoji keys
+ * should not be shown.
+ */
+bool KeyboardSettings::hideEmoji() const {
+    return m_settings->get(HIDE_EMOJI_KEY).toBool();
+}
+
+/*!
  * \brief KeyboardSettings::settingUpdated slot to handle changes in the settings backend
  * A specialized signal is emitted for the affected setting
  * \param key
@@ -307,6 +316,9 @@ void KeyboardSettings::settingUpdated(const QString &key)
         return;
     } else if (key == THEME_KEY) {
         Q_EMIT themeChanged(theme());
+        return;
+    } else if (key == HIDE_EMOJI_KEY) {
+        Q_EMIT hideEmojiChanged(hideEmoji());
         return;
     } else if (key == "device")
         Q_EMIT deviceChanged(device());

--- a/src/plugin/keyboardsettings.h
+++ b/src/plugin/keyboardsettings.h
@@ -64,6 +64,7 @@ public:
     double opacity() const;
     QString theme() const;
     QString device() const;
+    bool hideEmoji() const;
 
 Q_SIGNALS:
     void activeLanguageChanged(QString);
@@ -83,6 +84,7 @@ Q_SIGNALS:
     void opacityChanged(double);
     void themeChanged(const QString&);
     void deviceChanged(const QString&);
+    void hideEmojiChanged(bool);
 
 private:
     Q_SLOT void settingUpdated(const QString &key);


### PR DESCRIPTION
After the emoji layout was migrated to an internal mode users can no longer hide the emoji key.

This pull requests adds the hideEmoji setting to disable access to emoji layout through the Language Key and the Language Menu.