### PR TITLE
Fix unit tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,5 +26,5 @@ jobs:
 
       - name: Build
         run: |
-          cmake -DCMAKE_BUILD_TYPE=debug -DCMAKE_INSTALL_PREFIX=/usr .
+          cmake -DCMAKE_BUILD_TYPE=debug -DCMAKE_INSTALL_PREFIX=/usr -Denable-tests=ON .
           make -j8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,7 +431,7 @@ if(enable-tests)
             tests/unittests/common/utils.cpp
             tests/unittests/common/utils.h)
 
-    target_link_libraries(test-utils PUBLIC Qt5::Core Qt5::Gui Qt5::Test)
+    target_link_libraries(test-utils PUBLIC Qt5::Core Qt5::Gui Qt5::Test Maliit::Plugins)
     target_include_directories(test-utils INTERFACE tests/common tests maliit-keyboard)
 
     function(create_test name)

--- a/tests/unittests/common/utils-gui.cpp
+++ b/tests/unittests/common/utils-gui.cpp
@@ -33,8 +33,7 @@
 
 #include <QtCore>
 
-#include <QApplication>
-#include <QCommonStyle>
+#include <QGuiApplication>
 
 namespace TestUtils {
 

--- a/tests/unittests/common/utils.h
+++ b/tests/unittests/common/utils.h
@@ -35,7 +35,7 @@
 class QObject;
 class QString;
 class QCoreApplication;
-class QApplication;
+class QGuiApplication;
 
 namespace TestUtils {
 


### PR DESCRIPTION
If configured with `-Denable-tests=ON` the build fails due to unit tests not building under Void Linux (even on 4c07f7a2f35f277860208f1f50b9a48acdbd5835), full set of package with versions used for build:
```
=> maliit-keyboard-2.2.1.1r2469_1: building [cmake] for x86_64...
   [host] pkg-config-0.29.2_3: found (https://repo-default.voidlinux.org/current)
   [host] qt5-host-tools-5.15.3+20220222_3: found (https://repo-default.voidlinux.org/current)
   [host] qt5-qmake-5.15.3+20220222_3: found (https://repo-default.voidlinux.org/current)
   [host] gettext-0.21_4: found (https://repo-default.voidlinux.org/current)
   [host] cmake-3.22.2_1: found (https://repo-default.voidlinux.org/current)
   [host] ninja-1.11.0_1: found (https://repo-default.voidlinux.org/current)
   [target] maliit-framework-devel-2.2.1_1: found (/host/binpkgs/lomiri)
   [target] glib-devel-2.72.0_1: found (https://repo-default.voidlinux.org/current)
   [target] qt5-declarative-devel-5.15.3+20220222_3: found (https://repo-default.voidlinux.org/current)
   [target] qt5-feedback-devel-5.0.0r124_1: found (/host/binpkgs/lomiri)
   [target] qt5-multimedia-devel-5.15.3+20220222_3: found (https://repo-default.voidlinux.org/current)
   [target] hunspell-devel-1.7.0_3: found (https://repo-default.voidlinux.org/current)
   [target] libpinyin-devel-2.6.0_3: found (https://repo-default.voidlinux.org/current)
```
There's still an error which I've not yet figured out however:
```
/usr/lib/ccache/bin/g++ -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NO_DEBUG -DQT_TESTCASE_BUILDDIR=\"/builddir/keyboard-4c07f7a2f35f277860208f1f50b9a48acdbd5835/build\" -DQT_TESTLIB_LIB -I/builddir/keyboard-4c07f7a2f35f277860208f1f50b9a48acdbd5835/build -I/builddir/keyboard-4c07f7a2f35f277860208f1f50b9a48acdbd5835 -I/builddir/keyboard-4c07f7a2f35f277860208f1f50b9a48acdbd5835/build/test-utils_autogen/include -I /usr/include/qt5 -I /usr/include/qt5/QtCore -I /usr/lib/qt5/mkspecs/linux-g++ -I /usr/include/qt5/QtGui -I /usr/include/qt5/QtTest -DNDEBUG -fstack-clash-protection -D_FORTIFY_SOURCE=2 -mtune=generic -O2    -fdebug-prefix-map=/builddir/keyboard-4c07f7a2f35f277860208f1f50b9a48acdbd5835=. -fPIC -MD -MT CMakeFiles/test-utils.dir/tests/unittests/common/inputmethodhostprobe.cpp.o -MF CMakeFiles/test-utils.dir/tests/unittests/common/inputmethodhostprobe.cpp.o.d -o CMakeFiles/test-utils.dir/tests/unittests/common/inputmethodhostprobe.cpp.o -c /builddir/keyboard-4c07f7a2f35f277860208f1f50b9a48acdbd5835/tests/unittests/common/inputmethodhostprobe.cpp
In file included from /builddir/keyboard-4c07f7a2f35f277860208f1f50b9a48acdbd5835/tests/unittests/common/inputmethodhostprobe.cpp:32:
/builddir/keyboard-4c07f7a2f35f277860208f1f50b9a48acdbd5835/tests/unittests/common/inputmethodhostprobe.h:35:10: fatal error: maliit/plugins/abstractinputmethodhost.h: No such file or directory
   35 | #include <maliit/plugins/abstractinputmethodhost.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Looks like `-I/usr/include/maliit-2` is missing from that command line, I've confirmed my `maliit-framework-devel` package definitely contains `/usr/include/maliit-2/maliit/plugins/abstractinputmethodhost.h`.