### PR TITLE
inputmethod: Fix the settings URL for Plasma Mobile kcm renaming

### DIFF
--- a/src/plugin/inputmethod.cpp
+++ b/src/plugin/inputmethod.cpp
@@ -795,8 +795,8 @@ void InputMethod::showSystemSettings()
     auto previous = qgetenv("QT_WAYLAND_SHELL_INTEGRATION");
     qunsetenv("QT_WAYLAND_SHELL_INTEGRATION");
 
-    if (qgetenv("XDG_CURRENT_DESKTOP") == "KDE") {
-        QDesktopServices::openUrl(QUrl("systemsettings://kcm_mobile_virtualkeyboard"));
+    if (qEnvironmentVariable("PLASMA_PLATFORM").contains(QStringLiteral("phone"))) {
+        QDesktopServices::openUrl(QUrl("systemsettings://kcm_mobile_onscreenkeyboard"));
     } else {
         QDesktopServices::openUrl(QUrl("settings://system/language"));
     }


### PR DESCRIPTION
Also, check if we're using the phone session, as there is no settings
page for maliit on normal Plasma Desktop sessions.