### PR TITLE
qml: Use new syntax for Connections components

### DIFF
--- a/qml/Keyboard.qml
+++ b/qml/Keyboard.qml
@@ -255,7 +255,7 @@ Item {
 
         Connections {
             target: input_method
-            onActivateAutocaps: {
+            function onActivateAutocaps() {
                 if (keypad.state == "CHARACTERS" && keypad.activeKeypadState != "CAPSLOCK" && !cursorSwipe) {
                     keypad.activeKeypadState = "SHIFTED";
                     keypad.autoCapsTriggered = true;
@@ -264,10 +264,10 @@ Item {
                 }
             }
 
-            onKeyboardReset: {
+            function onKeyboardReset() {
                 keypad.state = "CHARACTERS"
             }
-            onDeactivateAutocaps: {
+            function onDeactivateAutocaps() {
                 if(keypad.autoCapsTriggered) {
                     keypad.activeKeypadState = "NORMAL";
                     keypad.autoCapsTriggered = false;

--- a/qml/keys/ActionsToolbarButton.qml
+++ b/qml/keys/ActionsToolbarButton.qml
@@ -28,7 +28,7 @@ AbstractButton {
 
         Connections {
             target: toolbarButton
-            onPressedChanged:{
+            function onPressedChanged(){
                 if (target.pressed) {
                     color = pressedColor
                 } else {

--- a/qml/keys/CharKey.qml
+++ b/qml/keys/CharKey.qml
@@ -338,7 +338,7 @@ Item {
 
     Connections {
         target: swipeArea.drag
-        onActiveChanged: {
+        function onActiveChanged() {
             if (swipeArea.drag.active)
                 keyMouseArea.cancelPress();
         }

--- a/qml/keys/FloatingActionKey.qml
+++ b/qml/keys/FloatingActionKey.qml
@@ -27,7 +27,7 @@ AbstractButton {
 
         Connections {
             target: floatingActionKey
-            onPressedChanged: {
+            function onPressedChanged() {
                 if (target.pressed) {
                     bg.color = pressedColor
                 } else {


### PR DESCRIPTION
Fix the following deprecation warnings from Qt 5.15:
Implicitly defined onFoo properties in Connections are deprecated.
Use this syntax instead: function onFoo(<arguments>) { ... }

Fixes #140