### PR TITLE
qml: Adjust word ribbon height to be less dependent on device units

### DIFF
--- a/qml/WordRibbon.qml
+++ b/qml/WordRibbon.qml
@@ -77,7 +77,7 @@ Page {
                 Layout.fillHeight: true
 
                 font.bold: isPrimaryCandidate || listView.count == 1
-                font.pixelSize: parent.height - Device.top_margin * 4
+                font.pixelSize: parent.height / 2
                 text: word
                 verticalAlignment: Text.AlignVCenter
                 horizontalAlignment: Text.AlignHCenter


### PR DESCRIPTION
On Steam Deck, after the previous word ribbon height adjustments, the text
remained quite small, so just use ribbon height / 2 now for font size, to
keep the relative size more consistent across devices.