### PR TITLE
Small improvements to CharKey

### DIFF
--- a/qml/keys/CharKey.qml
+++ b/qml/keys/CharKey.qml
@@ -182,7 +182,7 @@ Item {
                 anchors.top: parent.top
                 anchors.topMargin: Device.annotationTopMargin
                 anchors.rightMargin: Device.annotationRightMargin
-                font.pixelSize: key.fontSize / 2
+                font.pixelSize: key.fontSize / 2.25
                 font.weight: Font.Light
                 visible: !panel.hideKeyLabels
             }

--- a/qml/keys/CharKey.qml
+++ b/qml/keys/CharKey.qml
@@ -149,6 +149,8 @@ Item {
             icon.height: key.fontSize
             icon.width: key.fontSize
 
+            display: label == "" ? AbstractButton.IconOnly : AbstractButton.TextOnly
+
             /// label of the key
             //  the label is also the value subitted to the app
 


### PR DESCRIPTION
Make annotation font size slightly smaller to avoid potential overlap with main label, and set display mode of the ToolButton component to IconOnly if main label is empty, or TextOnly otherwise.