### PR TITLE
Make sure PressArea gets reset when the keyboard hides

### DIFF
--- a/qml/keys/PressArea.qml
+++ b/qml/keys/PressArea.qml
@@ -53,6 +53,8 @@ MultiPointTouchArea {
         holdTimer.stop();
     }
 
+    enabled: MaliitGeometry.shown
+
     touchPoints: [
         TouchPoint { 
             id: point


### PR DESCRIPTION
When the keyboard hides, pressed would remain true and hover events would still trigger as if the drag session never finished.

This makes sure that the press area gets disabled and the swipe works on consecutive Panel sessions.