### PR TITLE
Change vibration duration to 10ms

### DIFF
--- a/src/plugin/feedback.cpp
+++ b/src/plugin/feedback.cpp
@@ -55,7 +55,7 @@ Feedback::Feedback(const KeyboardSettings *settings)
     m_pressEffect->setAttackIntensity(0.0);
     m_pressEffect->setAttackTime(50);
     m_pressEffect->setIntensity(0.5);
-    m_pressEffect->setDuration(100);
+    m_pressEffect->setDuration(10);
     m_pressEffect->setFadeTime(50);
     m_pressEffect->setFadeIntensity(0.0);
 #endif


### PR DESCRIPTION
Change it to the original value prior to when it was hardcoded specifically for the PinePhone vibration motor: https://github.com/maliit/keyboard/pull/25.

Hardcoding it to long intervals makes the keyboard kind of unusable for non-pinephone devices. 

To properly fix this for the pinephone, it should be done from the vibration driver or underlying stack, not from here