### PR TITLE
Keyboard: Change swipe dismiss gesture to animate opacity instead of position

### DIFF
--- a/qml/keys/CharKey.qml
+++ b/qml/keys/CharKey.qml
@@ -383,12 +383,4 @@ Item {
             keyMouseArea.evaluateSelectorSwipe();
         }
     }
-
-    Connections {
-        target: swipeArea.drag
-        function onActiveChanged() {
-            if (swipeArea.drag.active)
-                keyMouseArea.cancelPress();
-        }
-    }
 }

--- a/qml/keys/PressArea.qml
+++ b/qml/keys/PressArea.qml
@@ -86,13 +86,9 @@ MultiPointTouchArea {
                         lastY = point.y;
                         lastYChange = distance;
                     }
-                    // Hide if we get close to the bottom of the screen.
-                    // This works around issues with devices with touch buttons
-                    // below the screen preventing release events when swiped
-                    // over
-                    if(point.sceneY > fullScreenItem.height - Device.gu(4) && point.y > startY + Device.gu(8) && !held) {
-                        Keyboard.hide();
-                    }
+
+                    // send swipe event to keyboard container
+                    swipeArea.swipeDelta(distance);
                 } else {
                     lastY = point.y;
                 }
@@ -141,22 +137,8 @@ MultiPointTouchArea {
     }
 
     onReleased: {
-        // Don't evaluate if the release point is above the start point
-        // or further away from its start than the height of the whole keyboard.
-        // This works around touches sometimes being recognized as ending below
-        // the bottom of the screen.
-        if (point.y > panel.height) {
-            console.warn("Touch point released past height of keyboard. Ignoring.");
-        } else if (!(point.y <= startY)) {
-            // Handles swiping away the keyboard
-            // Hide if the end point is more than 8 grid units from the start
-            if (!held && point.y > startY + Device.gu(8)) {
-                Keyboard.hide();
-            } else {
-                bounceBackAnimation.from = keyboardSurface.y;
-                bounceBackAnimation.start();
-            }
-        }
+        // send release event to keyboard container
+        swipeArea.swipeRelease();
 
         pressed = false;
         held = false;


### PR DESCRIPTION
See rationale on https://github.com/maliit/keyboard/pull/157, but TLDR we encounter a lot of issues with animating the position of the keyboard.

Here we instead change to animate the opacity, which allows the keyboard retain its dimensions during the animation.