### PR TITLE
qml: Fix .укр domain on ru keypad

### DIFF
--- a/plugins/ru/qml/Keyboard_ru_url.qml
+++ b/plugins/ru/qml/Keyboard_ru_url.qml
@@ -91,7 +91,7 @@ KeyPad {
             SymbolShiftKey { id: symShiftKey;                            anchors.left: parent.left; height: parent.height; }
             LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
             CharKey        { id: slashKey; label: "/"; shifted: "/";     anchors.left: languageMenuButton.right; height: parent.height; }
-            UrlKey         { id: urlKey; label: ".ru"; extended: [".com", ".ua",".su",".kg",".рф","укр",".by",".tj"]; anchors.right: dotKey.left; height: parent.height; }
+            UrlKey         { id: urlKey; label: ".ru"; extended: [".com", ".ua",".su",".kg",".рф",".укр",".by",".tj"]; anchors.right: dotKey.left; height: parent.height; }
             CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?", "-", "_", "!", "+", "%","#","/"]; extendedShifted: ["?", "-", "_", "!", "+", "%","#","/"]; anchors.right: enterKey.left; height: parent.height; }
             ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
         }

--- a/plugins/ru/qml/Keyboard_ru_url_search.qml
+++ b/plugins/ru/qml/Keyboard_ru_url_search.qml
@@ -92,7 +92,7 @@ KeyPad {
             LanguageKey    { id: languageMenuButton;                     anchors.left: symShiftKey.right; height: parent.height; }
             CharKey        { id: slashKey; label: "/"; shifted: "/";     anchors.left: languageMenuButton.right; height: parent.height; }
             SpaceKey       { id: spaceKey;                               anchors.left: slashKey.right; anchors.right: urlKey.left; noMagnifier: true; height: parent.height; }
-            UrlKey         { id: urlKey; label: ".ru"; extended: [".com", ".ua",".su",".kg",".рф","укр",".by",".tj"]; anchors.right: dotKey.left; height: parent.height; }
+            UrlKey         { id: urlKey; label: ".ru"; extended: [".com", ".ua",".su",".kg",".рф",".укр",".by",".tj"]; anchors.right: dotKey.left; height: parent.height; }
             CharKey        { id: dotKey;      label: "."; shifted: "."; extended: ["?", "-", "_", "!", "+", "%","#","/"]; extendedShifted: ["?", "-", "_", "!", "+", "%","#","/"]; anchors.right: enterKey.left; height: parent.height; }
             ReturnKey      { id: enterKey;                               anchors.right: parent.right; height: parent.height; }
         }


### PR DESCRIPTION
In Russian layouts, the extended keys list contains the [.укр](https://en.wikipedia.org/wiki/.%D1%83%D0%BA%D1%80) domain without a dot. Please add a dot