### PR TITLE
Fix settings URL for plasma 6

### DIFF
--- a/src/plugin/inputmethod.cpp
+++ b/src/plugin/inputmethod.cpp
@@ -790,6 +790,8 @@ void InputMethod::showSystemSettings()
 
     if (qEnvironmentVariable("PLASMA_PLATFORM").contains(QStringLiteral("phone"))) {
         QDesktopServices::openUrl(QUrl("systemsettings://kcm_mobile_onscreenkeyboard"));
+    } else if (qEnvironmentVariable("KDE_SESSION_VERSION").contains(QStringLiteral("6"))) {
+        QDesktopServices::openUrl(QUrl("systemsettings://kcm_regionandlang"));
     } else {
         QDesktopServices::openUrl(QUrl("settings://system/language"));
     }


### PR DESCRIPTION
When opening settings from language menu I get:
![image](https://github.com/user-attachments/assets/f85633be-bd46-4c4e-b9f5-8bbc95c02f6d)

So update the url to open `Region & Language` settings page (though I am not sure if it should be the Keyboard/Keyboard/Layouts page instead) in plasma 6.
