### PR TITLE
Add support for more keys

### DIFF
--- a/qml/keys/CapsLockKey.qml
+++ b/qml/keys/CapsLockKey.qml
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Vojtěch Pluskal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+
+import QtQuick.Controls 2.12
+import QtQuick.Window 2.12
+import MaliitKeyboard 2.0
+
+ActionKey {
+    overridePressArea: true
+
+    Rectangle {
+        anchors.margins: 8
+        anchors.fill: parent
+        color: "#888888"
+        radius: 8 / Screen.devicePixelRatio
+        opacity: panel.activeKeypadState == "CAPSLOCK" ? 0.0 : 0.25
+    }
+
+    Label {
+        anchors.centerIn: parent
+        font.weight: Font.Light
+        opacity: 0.6
+        font.pixelSize: parent.fontSize * 0.6
+        text: "caps lock"
+        horizontalAlignment: Text.AlignHCenter
+    }
+
+    MouseArea {
+       anchors.fill: parent
+
+       onPressed: {
+           Feedback.keyPressed();
+
+           if (panel.activeKeypadState == "NORMAL")
+               panel.activeKeypadState = "CAPSLOCK";
+           else if (panel.activeKeypadState == "SHIFTED")
+               panel.activeKeypadState = "CAPSLOCK"
+           else if (panel.activeKeypadState == "CAPSLOCK")
+               panel.activeKeypadState = "NORMAL"
+       }
+    }
+}

--- a/qml/keys/DownKey.qml
+++ b/qml/keys/DownKey.qml
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Vojtěch Pluskal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+
+ActionKey {
+    label: "↓"
+    shifted: "↓"
+    action: "down";
+}

--- a/qml/keys/EndKey.qml
+++ b/qml/keys/EndKey.qml
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Vojtěch Pluskal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+
+ActionKey {
+    label: "end"
+    shifted: "end"
+    action: "end";
+}

--- a/qml/keys/EscapeKey.qml
+++ b/qml/keys/EscapeKey.qml
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Vojtěch Pluskal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+
+ActionKey {
+    label: "esc"
+    shifted: "esc"
+    action: "escape";
+}

--- a/qml/keys/HomeKey.qml
+++ b/qml/keys/HomeKey.qml
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Vojtěch Pluskal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+
+ActionKey {
+    label: "home"
+    shifted: "home"
+    action: "home";
+}

--- a/qml/keys/LeftKey.qml
+++ b/qml/keys/LeftKey.qml
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Vojtěch Pluskal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+
+ActionKey {
+    label: "←"
+    shifted: "←"
+    action: "left";
+}

--- a/qml/keys/PageDownKey.qml
+++ b/qml/keys/PageDownKey.qml
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Vojtěch Pluskal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+
+ActionKey {
+    label: "page down"
+    shifted: "page down"
+    action: "pagedown";
+}

--- a/qml/keys/PageUpKey.qml
+++ b/qml/keys/PageUpKey.qml
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Vojtěch Pluskal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+
+ActionKey {
+    label: "page up"
+    shifted: "page up"
+    action: "pageup";
+}

--- a/qml/keys/RightKey.qml
+++ b/qml/keys/RightKey.qml
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Vojtěch Pluskal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+
+ActionKey {
+    label: "→"
+    shifted: "→"
+    action: "right";
+}

--- a/qml/keys/TabKey.qml
+++ b/qml/keys/TabKey.qml
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Vojtěch Pluskal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+
+ActionKey {
+    label: "↹"
+    shifted: "↹"
+    action: "tab";
+}

--- a/qml/keys/UpKey.qml
+++ b/qml/keys/UpKey.qml
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Vojtěch Pluskal
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.4
+
+ActionKey {
+    label: "↑"
+    shifted: "↑"
+    action: "up";
+}

--- a/qml/keys/qmldir
+++ b/qml/keys/qmldir
@@ -18,3 +18,14 @@ PressArea 1.0 PressArea.qml
 SpaceKey 1.0 SpaceKey.qml
 UrlKey 1.0 UrlKey.qml
 CategoryKey 1.0 CategoryKey.qml
+UpKey 1.0 UpKey.qml
+DownKey 1.0 DownKey.qml
+LeftKey 1.0 LeftKey.qml
+RightKey 1.0 RightKey.qml
+EscapeKey 1.0 EscapeKey.qml
+TabKey 1.0 TabKey.qml
+HomeKey 1.0 HomeKey.qml
+EndKey 1.0 EndKey.qml
+PageUpKey 1.0 PageUpKey.qml
+PageDownKey 1.0 PageDownKey.qml
+CapsLockKey 1.0 CapsLockKey.qml

--- a/src/lib/models/key.h
+++ b/src/lib/models/key.h
@@ -72,6 +72,9 @@ public:
         ActionRightLayout, //!< Switch to right/next language layout.
         ActionHome, //!< Key moves cursor to beginning of text.
         ActionEnd, //!< Key moves cursor to end of text.
+        ActionEscape, //!< Key sends Escape
+        ActionPageUp, //!< Key sends PageUp
+        ActionPageDown, //!< Key sends PageDown
         NumActions
     };
 

--- a/src/view/abstracttexteditor.cpp
+++ b/src/view/abstracttexteditor.cpp
@@ -617,11 +617,11 @@ void AbstractTextEditor::onKeyReleased(const Key &key)
     case Key::ActionDown:
         event_key = Qt::Key_Down;
         break;
-        
+
     case Key::ActionKeySequence:
         sendKeySequence(text, QKeySequence::fromString(key.commandSequence()));
         break;
-        
+
     case Key::ActionCommand:
         invokeAction(text, QKeySequence::fromString(key.commandSequence()));
         break;
@@ -640,6 +640,22 @@ void AbstractTextEditor::onKeyReleased(const Key &key)
 
     case Key::ActionEnd:
         event_key = Qt::Key_End;
+        break;
+
+    case Key::ActionEscape:
+        event_key = Qt::Key_Escape;
+        break;
+
+    case Key::ActionPageUp:
+        event_key = Qt::Key_PageUp;
+        break;
+
+    case Key::ActionPageDown:
+        event_key = Qt::Key_PageDown;
+        break;
+
+    case Key::ActionTab:
+        event_key = Qt::Key_Tab;
         break;
 
     default:


### PR DESCRIPTION
Adds support for some keys, which would be required for a standard keyboard layout. Some notes:

- The tab and arrow keys currently use labels, but icons may be better (I used labels as I was unable to find a list of icon names), especially for the tab key.
- My comments in [src/lib/models/key.h](https://github.com/maliit/keyboard/compare/master...vojtapl:keyboard:add-support-for-new-keys#diff-f0c4353e569a71e98e09551d4f7c89572dcb4ea03ff02e9c8b1821afb5b652d4) are a bit lackluster.