### PR TITLE
qml: Don't break the emoji keyboard if LocalStorage fails

### DIFF
--- a/qml/languages/Keyboard_emoji.qml
+++ b/qml/languages/Keyboard_emoji.qml
@@ -38,7 +38,20 @@ KeyPad {
         property var db
 
         Component.onCompleted: {
-            db = LocalStorage.openDatabaseSync("Emoji", "1.0", "Storage for emoji keyboard layout", 1000000);
+            try {
+                db = LocalStorage.openDatabaseSync("Emoji", "1.0", "Storage for emoji keyboard layout", 1000000);
+            } catch(e) {
+                console.log("Couldn't initialize local storage for emoji keyboard: " + e)
+                db = {
+                    transaction: function(txfun) {
+                        txfun({
+                            executeSql: function(sql) {
+                                return { rows: [] }
+                            }
+                        })
+                    }
+                }
+            }
 
             db.transaction(
                 function(tx) {


### PR DESCRIPTION
Some conditions (like missing access rights to create the database path) may lead the LocalStorage.openDatabaseSync call to fail. This causes the db variable to point to an undefined value, which breaks generating and displaying the list of emojis.

Instead of handling the failed database at every usage, simply provide a bare minimum dummy implementation that doesn't store anything and just returns empty query results. This allows the rest of the code to stay the same.